### PR TITLE
feat: add functions to handle each method

### DIFF
--- a/src/handle_selector.rs
+++ b/src/handle_selector.rs
@@ -49,10 +49,8 @@ impl<'a> HandlerSelect<'a> {
                 (None, Some(wildcard_node)) => root = wildcard_node.as_ref(),
                 (Some(childrens), None) => {
                     if childrens.contains_key(splitted_path) {
-                        println!("Sla");
                         root = childrens.get(splitted_path).unwrap();
                     } else {
-                        println!("Sla2");
                         return None;
                     }
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,8 +152,8 @@ mod tests {
         ))
     }
 
-    async fn run_test(server: &Server<'_>, _req: Request<String>) -> GenericHttpResponse {
-        let method = _req.method();
+    async fn run_test(server: &Server<'_>, req: Request<String>) -> GenericHttpResponse {
+        let method = req.method();
         let our_method = match *method {
             http::Method::GET => Method::Get,
             http::Method::POST => Method::Post,
@@ -162,7 +162,7 @@ mod tests {
             _ => unreachable!("Wrong tests for the moment"),
         };
 
-        let path = _req.uri().path().to_string();
+        let path = req.uri().path().to_string();
 
         println!("{}", path);
 
@@ -170,7 +170,7 @@ mod tests {
 
         assert!(handler.is_some());
 
-        handler.unwrap()(RequestWrapper::new(_req.into_body())).await
+        handler.unwrap()(RequestWrapper::new(req.into_body())).await
     }
 
     #[async_test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,32 +2,129 @@ mod error;
 mod handle_selector;
 mod handler;
 
-use crate::handler::{BodyExtractors, CRunner, RealRunner};
+use crate::handler::{BodyExtractors, CRunner, RealRunner, RefAsyncHandler};
 use handle_selector::HandlerSelect;
 
 #[derive(Default)]
 pub struct Server<'a> {
-    handler_selector: HandlerSelect<'a>,
+    get: HandlerSelect<'a>,
+    put: HandlerSelect<'a>,
+    delete: HandlerSelect<'a>,
+    post: HandlerSelect<'a>,
+}
+
+pub enum Method {
+    Get,
+    Post,
+    Put,
+    Delete,
 }
 
 impl<'a> Server<'a> {
     pub fn new() -> Self {
         Self {
-            handler_selector: HandlerSelect::new(),
+            get: HandlerSelect::new(),
+            put: HandlerSelect::new(),
+            delete: HandlerSelect::new(),
+            post: HandlerSelect::new(),
         }
     }
 
     pub fn add_handler<Req, Res, BodyType, Extractor, R>(
         &mut self,
+        method: Method,
         path: &'static str,
         handler: &'static R,
-        extractor: Extractor,
+        extractor: &Extractor,
     ) where
         R: 'static + RealRunner<Req, Res, Extractor, BodyType>,
         Extractor: BodyExtractors<Item = BodyType>,
     {
-        self.handler_selector
-            .insert(path, handler.create_runner(extractor));
+        match method {
+            Method::Get => self.get.insert(path, handler.create_runner(extractor)),
+            Method::Put => self.put.insert(path, handler.create_runner(extractor)),
+            Method::Delete => self.delete.insert(path, handler.create_runner(extractor)),
+            Method::Post => self.post.insert(path, handler.create_runner(extractor)),
+        }
+    }
+
+    pub fn get<Req, Res, BodyType, Extractor, R>(
+        &mut self,
+        path: &'static str,
+        handler: &'static R,
+        extractor: &Extractor,
+    ) where
+        R: 'static + RealRunner<Req, Res, Extractor, BodyType>,
+        Extractor: BodyExtractors<Item = BodyType>,
+    {
+        self.add_handler(Method::Get, path, handler, extractor)
+    }
+
+    pub fn post<Req, Res, BodyType, Extractor, R>(
+        &mut self,
+        path: &'static str,
+        handler: &'static R,
+        extractor: &Extractor,
+    ) where
+        R: 'static + RealRunner<Req, Res, Extractor, BodyType>,
+        Extractor: BodyExtractors<Item = BodyType>,
+    {
+        self.add_handler(Method::Post, path, handler, extractor)
+    }
+
+    pub fn put<Req, Res, BodyType, Extractor, R>(
+        &mut self,
+        path: &'static str,
+        handler: &'static R,
+        extractor: &Extractor,
+    ) where
+        R: 'static + RealRunner<Req, Res, Extractor, BodyType>,
+        Extractor: BodyExtractors<Item = BodyType>,
+    {
+        self.add_handler(Method::Put, path, handler, extractor)
+    }
+
+    pub fn delete<Req, Res, BodyType, Extractor, R>(
+        &mut self,
+        path: &'static str,
+        handler: &'static R,
+        extractor: &Extractor,
+    ) where
+        R: 'static + RealRunner<Req, Res, Extractor, BodyType>,
+        Extractor: BodyExtractors<Item = BodyType>,
+    {
+        self.add_handler(Method::Delete, path, handler, extractor)
+    }
+
+    pub fn all<Req, Res, BodyType, Extractor, R>(
+        &mut self,
+        path: &'static str,
+        handler: &'static R,
+        extractor: &Extractor,
+    ) where
+        R: 'static + RealRunner<Req, Res, Extractor, BodyType>,
+        Extractor: BodyExtractors<Item = BodyType>,
+    {
+        if let (None, None, None, None) = (
+            self.get.get(path),
+            self.post.get(path),
+            self.put.get(path),
+            self.delete.get(path),
+        ) {
+            self.get.insert(path, handler.create_runner(extractor));
+            self.post.insert(path, handler.create_runner(extractor));
+            self.put.insert(path, handler.create_runner(extractor));
+            self.delete.insert(path, handler.create_runner(extractor));
+        }
+    }
+
+    pub fn find_handler(&'a self, method: Method, path: &'a str) -> Option<RefAsyncHandler<'a>> {
+        match method {
+            Method::Get => self.get.get(path),
+            Method::Put => self.put.get(path),
+            Method::Post => self.post.get(path),
+            Method::Delete => self.delete.get(path),
+        }
     }
 }
 
@@ -41,10 +138,10 @@ mod tests {
     use crate::{
         error::Error,
         handler::{GenericHttpResponse, Json, RequestWrapper},
-        Server,
+        Method, Server,
     };
 
-    #[derive(Debug, Deserialize, Serialize, Default)]
+    #[derive(Clone, Debug, Deserialize, Serialize, Default)]
     struct TestStruct {
         correct: bool,
     }
@@ -55,21 +152,44 @@ mod tests {
         ))
     }
 
+    async fn run_test(server: &Server<'_>, _req: Request<String>) -> GenericHttpResponse {
+        let method = _req.method();
+        let our_method = match *method {
+            http::Method::GET => Method::Get,
+            http::Method::POST => Method::Post,
+            http::Method::PUT => Method::Put,
+            http::Method::DELETE => Method::Delete,
+            _ => unreachable!("Wrong tests for the moment"),
+        };
+
+        let path = _req.uri().path().to_string();
+
+        println!("{}", path);
+
+        let handler = server.find_handler(our_method, &path);
+
+        assert!(handler.is_some());
+
+        handler.unwrap()(RequestWrapper::new(_req.into_body())).await
+    }
+
     #[async_test]
     async fn test_handler_receiving_req_and_res() -> std::io::Result<()> {
         let mut server = Server::new();
 
-        server.add_handler("/aaaa/bbbb", &test_handler_with_req_and_res, Json::new());
+        server.add_handler(
+            Method::Get,
+            "/aaaa/bbbb",
+            &test_handler_with_req_and_res,
+            &Json::new(),
+        );
 
-        let handler = server.handler_selector.get("/aaaa/bbbb");
+        let request = Request::builder()
+            .uri("/aaaa/bbbb")
+            .body(serde_json::json!({ "correct": false }).to_string())
+            .unwrap();
 
-        assert!(handler.is_some());
-
-        let unwraped_handler = handler.unwrap();
-
-        let request = RequestWrapper::new(serde_json::json!({ "correct": false }).to_string());
-
-        let response = unwraped_handler(request).await;
+        let response = run_test(&server, request).await;
 
         assert!(
             response.is_ok(),
@@ -84,6 +204,54 @@ mod tests {
             *response.unwrap().body(),
             serde_json::json!({ "correct": true }).to_string()
         );
+
+        Ok(())
+    }
+
+    #[async_test]
+    async fn test_all_servers() -> std::io::Result<()> {
+        let mut server = Server::new();
+
+        server.all("/test/all", &test_handler_with_req_and_res, &Json::new());
+
+        let req_body = serde_json::json!({ "correct": false }).to_string();
+        let expected_res_body = serde_json::json!({ "correct": true }).to_string();
+
+        let request = Request::builder()
+            .uri("/test/all")
+            .method(http::Method::GET)
+            .body(req_body.clone())
+            .unwrap();
+        let response = run_test(&server, request).await;
+
+        assert_eq!(*response.unwrap().body(), expected_res_body.clone());
+
+        let request = Request::builder()
+            .uri("/test/all")
+            .method(http::Method::POST)
+            .body(req_body.clone())
+            .unwrap();
+        let response = run_test(&server, request).await;
+
+        assert_eq!(*response.unwrap().body(), expected_res_body.clone());
+
+        let request = Request::builder()
+            .uri("/test/all")
+            .method(http::Method::PUT)
+            .body(req_body.clone())
+            .unwrap();
+        let response = run_test(&server, request).await;
+
+        assert_eq!(*response.unwrap().body(), expected_res_body.clone());
+
+        let request = Request::builder()
+            .uri("/test/all")
+            .method(http::Method::DELETE)
+            .body(req_body.clone())
+            .unwrap();
+        let response = run_test(&server, request).await;
+
+        assert_eq!(*response.unwrap().body(), expected_res_body.clone());
 
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,7 +141,7 @@ mod tests {
         Method, Server,
     };
 
-    #[derive(Clone, Debug, Deserialize, Serialize, Default)]
+    #[derive(Debug, Deserialize, Serialize)]
     struct TestStruct {
         correct: bool,
     }


### PR DESCRIPTION
## About

Create the `Server` functions:
- `get`: bind a `handler` to a `path` when receiving a `GET` request;
- `post`: bind a `handler` to a `path` when receiving a `POST` request;
- `put`: bind a `handler` to a `path` when receiving a `PUT` request;
- `delete`: bind a `handler` to a `path` when receiving a `DELETE` request;
- `all`: bind a `handler` to a `path` when receiving either a `GET`, a `POST`, a `PUT`, or a `DELETE` request.