### PR TITLE
Refactor/improve runner trait

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,11 +1,18 @@
-#[derive(Debug)]
-pub struct HttpError {
-    pub _code: u32,
-    pub _body: String,
-}
+use crate::response::Response;
 
 #[derive(Debug)]
-pub enum Error {
-    ParseBody(String),
-    RequestError(HttpError),
+pub struct Error {
+    body: String,
+}
+
+impl Error {
+    pub fn new(body: String) -> Self {
+        Self { body }
+    }
+}
+
+impl From<Error> for Response<String> {
+    fn from(val: Error) -> Self {
+        Response::new(val.body)
+    }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,16 +3,17 @@ use crate::response::Response;
 #[derive(Debug)]
 pub struct Error {
     body: String,
+    code: u16,
 }
 
 impl Error {
-    pub fn new(body: String) -> Self {
-        Self { body }
+    pub fn new(body: String, code: u16) -> Self {
+        Self { body, code }
     }
 }
 
 impl From<Error> for Response<String> {
     fn from(val: Error) -> Self {
-        Response::new(val.body)
+        Response::builder().status(val.code).body(val.body)
     }
 }

--- a/src/handle_selector.rs
+++ b/src/handle_selector.rs
@@ -1,12 +1,12 @@
 use std::collections::HashMap;
 
-use crate::handler::{BoxedAsyncHandler, RefAsyncHandler};
+use crate::handler::{BoxedHandler, RefHandler};
 
 #[derive(Default)]
 struct Node<'a> {
     childrens: Option<HashMap<&'a str, Node<'a>>>,
     wildcard_node: Option<Box<Node<'a>>>,
-    value: Option<BoxedAsyncHandler>,
+    value: Option<BoxedHandler>,
 }
 
 #[derive(Default)]
@@ -25,7 +25,7 @@ impl<'a> HandlerSelect<'a> {
         }
     }
 
-    pub fn insert(&mut self, path: &'a str, handler: BoxedAsyncHandler) {
+    pub fn insert(&mut self, path: &'a str, handler: BoxedHandler) {
         let mut node = &mut self.root;
         for splitted_path in path.split('/').filter(|x| !x.is_empty()) {
             if is_parameter_declaration(splitted_path) {
@@ -40,7 +40,7 @@ impl<'a> HandlerSelect<'a> {
     }
 
     #[allow(dead_code)]
-    pub fn get(&self, path: &'a str) -> Option<RefAsyncHandler<'_>> {
+    pub fn get(&self, path: &'a str) -> Option<RefHandler<'_>> {
         let mut root = &self.root;
 
         for splitted_path in path.split('/').filter(|x| !x.is_empty()) {

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -228,6 +228,12 @@ mod tests {
         Response::new(SomeBodyType { field: new_field })
     }
 
+    async fn unit_handler_with_response_body() -> SomeBodyType {
+        let new_field = String::from("HOPE - NF");
+
+        SomeBodyType { field: new_field }
+    }
+
     async fn simple_handler_with_body(input: SomeBodyType) -> Response<SomeBodyType> {
         let mut new_field = input.field;
         new_field.push_str(" - Halsey");
@@ -260,6 +266,23 @@ mod tests {
     #[async_test]
     async fn test_unit_handler_implements_runner() -> std::io::Result<()> {
         let a = encapsulate_runner(unit_handler, &(), &Json::new());
+        let c = Request::builder()
+            .body(serde_json::json!({ "field": "South of the border" }).to_string());
+        let b = a(c).await;
+
+        let expected_field_result = "HOPE - NF";
+
+        assert_eq!(
+            b.body().as_str(),
+            serde_json::json!({ "field": expected_field_result }).to_string()
+        );
+
+        Ok(())
+    }
+
+    #[async_test]
+    async fn test_unit_handler_with_response_body_implements_runner() -> std::io::Result<()> {
+        let a = encapsulate_runner(unit_handler_with_response_body, &(), &Json::new());
         let c = Request::builder()
             .body(serde_json::json!({ "field": "South of the border" }).to_string());
         let b = a(c).await;

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -13,18 +13,18 @@ pub type RefHandler<'a> =
     &'a dyn Fn(GenericRequest) -> Pin<Box<dyn Future<Output = GenericResponse>>>;
 
 #[derive(Debug)]
-pub struct SerdeError {
+pub struct Error {
     body: String,
 }
 
-impl SerdeError {
+impl Error {
     pub fn new(body: String) -> Self {
         Self { body }
     }
 }
 
-impl From<SerdeError> for GenericResponse {
-    fn from(val: SerdeError) -> Self {
+impl From<Error> for GenericResponse {
+    fn from(val: Error) -> Self {
         GenericResponse::new(val.body)
     }
 }
@@ -66,7 +66,7 @@ impl Builder {
     }
 }
 
-type Result<T> = std::result::Result<T, SerdeError>;
+type Result<T> = std::result::Result<T, Error>;
 
 impl<T> Request<T> {
     pub fn new(value: T) -> Self {
@@ -274,7 +274,7 @@ where
     where
         Self: std::marker::Sized,
     {
-        serde_json::from_str(content).map_err(|err| SerdeError {
+        serde_json::from_str(content).map_err(|err| Error {
             body: err.to_string(),
         })
     }
@@ -287,7 +287,7 @@ where
     type Item = T;
 
     fn serialize(content: &Self::Item) -> Result<String> {
-        serde_json::to_string(content).map_err(|err| SerdeError {
+        serde_json::to_string(content).map_err(|err| Error {
             body: err.to_string(),
         })
     }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -125,6 +125,67 @@ where
     }
 }
 
+mod improv {
+    #[derive(Debug)]
+    pub struct SerdeError {
+        body: String,
+    }
+
+    impl SerdeError {
+        pub fn new(body: String) -> Self {
+            Self { body }
+        }
+    }
+
+    pub struct Request<T> {
+        body: T,
+    }
+
+    type Result<T> = std::result::Result<T, SerdeError>;
+
+    impl<T> Request<T> {
+        fn new(value: T) -> Self {
+            Self { body: value }
+        }
+
+        fn body(&self) -> &T {
+            &self.body
+        }
+
+        // TODO: Valuate if this will keep this fn or move to an from_parts style
+        fn and_then<BodyType>(
+            self,
+            callback: impl FnOnce(T) -> Result<BodyType>,
+        ) -> Result<Request<BodyType>> {
+            let body = self.body;
+            callback(body).map(Request::<BodyType>::new)
+        }
+    }
+
+    pub struct Response<T> {
+        body: T,
+    }
+
+    impl<T> Response<T> {
+        fn new(value: T) -> Self {
+            Self { body: value }
+        }
+
+        fn body(&self) -> &T {
+            &self.body
+        }
+
+        // TODO: Valuate if this will keep this fn or move to an from_parts style
+        fn and_then<BodyType>(
+            self,
+            callback: impl FnOnce(T) -> Result<BodyType>,
+        ) -> Result<Response<BodyType>> {
+            let body = self.body;
+            callback(body).map(Response::<BodyType>::new)
+        }
+    }
+}
+
 #[cfg(test)]
 mod async_runner {
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -126,6 +126,12 @@ where
 }
 
 mod improv {
+    use std::{marker::PhantomData, pin::Pin};
+
+    use async_trait::async_trait;
+    use futures::Future;
+    use serde::{de::DeserializeOwned, Serialize};
+
     #[derive(Debug)]
     pub struct SerdeError {
         body: String,
@@ -352,6 +358,128 @@ mod improv {
         R: Runner<(FnInput, Deserializer), (FnOutput, Serializer)>,
     {
         runner.call_runner(req).await
+    }
+
+    #[cfg(test)]
+    mod improv_tests {
+        use std::marker::PhantomData;
+
+        use async_std_test::async_test;
+        use serde::{Deserialize, Serialize};
+
+        use crate::handler::improv::Json;
+
+        use super::{encapsulate_runner, Request, Response};
+
+        #[derive(Deserialize, Serialize)]
+        struct SomeBodyType {
+            field: String,
+        }
+
+        async fn simple_handler(input: Request<SomeBodyType>) -> Response<SomeBodyType> {
+            let mut new_field = input.body().field.to_owned();
+            new_field.push_str(" - Ed Sheeran");
+
+            Response::new(SomeBodyType { field: new_field })
+        }
+
+        async fn unit_handler() -> Response<SomeBodyType> {
+            let new_field = String::from("HOPE - NF");
+
+            Response::new(SomeBodyType { field: new_field })
+        }
+
+        async fn simple_handler_with_body(input: SomeBodyType) -> Response<SomeBodyType> {
+            let mut new_field = input.field;
+            new_field.push_str(" - Halsey");
+
+            Response::new(SomeBodyType { field: new_field })
+        }
+
+        async fn handler_with_simple_body_on_input_and_output(input: SomeBodyType) -> SomeBodyType {
+            let mut new_field = input.field;
+            new_field.push_str(" - Imagine Dragons");
+
+            SomeBodyType { field: new_field }
+        }
+
+        #[async_test]
+        async fn test_simple_handler_implements_runner() -> std::io::Result<()> {
+            let a = encapsulate_runner(simple_handler, &Json(PhantomData), &Json(PhantomData));
+            let b = a(Request {
+                body: serde_json::json!({ "field": "South of the border" }).to_string(),
+            })
+            .await;
+
+            assert_eq!(
+                b.unwrap().body().as_str(),
+                serde_json::json!({ "field": "South of the border - Ed Sheeran"  }).to_string()
+            );
+
+            Ok(())
+        }
+
+        #[async_test]
+        async fn test_unit_handler_implements_runner() -> std::io::Result<()> {
+            let a = encapsulate_runner(unit_handler, &(), &Json(PhantomData));
+            let b = a(Request {
+                body: serde_json::json!({ "field": "South of the border" }).to_string(),
+            })
+            .await;
+
+            let expected_field_result = "HOPE - NF";
+
+            assert_eq!(
+                b.unwrap().body().as_str(),
+                serde_json::json!({ "field": expected_field_result }).to_string()
+            );
+
+            Ok(())
+        }
+
+        #[async_test]
+        async fn test_simple_handler_with_body_implements_runner() -> std::io::Result<()> {
+            let a = encapsulate_runner(
+                simple_handler_with_body,
+                &Json(PhantomData),
+                &Json(PhantomData),
+            );
+            let b = a(Request {
+                body: serde_json::json!({ "field": "So Good" }).to_string(),
+            })
+            .await;
+
+            let expected_field_result = "So Good - Halsey";
+
+            assert_eq!(
+                b.unwrap().body().as_str(),
+                serde_json::json!({ "field": expected_field_result }).to_string()
+            );
+
+            Ok(())
+        }
+
+        #[async_test]
+        async fn test_handler_with_simple_body_on_input_and_output_runner() -> std::io::Result<()> {
+            let a = encapsulate_runner(
+                handler_with_simple_body_on_input_and_output,
+                &Json(PhantomData),
+                &Json(PhantomData),
+            );
+            let b = a(Request {
+                body: serde_json::json!({ "field": "Sharks" }).to_string(),
+            })
+            .await;
+
+            let expected_field_result = "Sharks - Imagine Dragons";
+
+            assert_eq!(
+                b.unwrap().body().as_str(),
+                serde_json::json!({ "field": expected_field_result }).to_string()
+            );
+
+            Ok(())
+        }
     }
 }
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -152,7 +152,7 @@ where
     where
         Self: std::marker::Sized,
     {
-        serde_json::from_str(content).map_err(|err| Error::new(err.to_string()))
+        serde_json::from_str(content).map_err(|err| Error::new(err.to_string(), 422))
     }
 }
 
@@ -163,7 +163,7 @@ where
     type Item = T;
 
     fn serialize(content: &Self::Item) -> Result<String> {
-        serde_json::to_string(content).map_err(|err| Error::new(err.to_string()))
+        serde_json::to_string(content).map_err(|err| Error::new(err.to_string(), 422))
     }
 }
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -2,536 +2,362 @@ use std::{marker::PhantomData, pin::Pin};
 
 use async_trait::async_trait;
 use futures::Future;
-use http::{Request, Response};
-use serde::de::DeserializeOwned;
+use serde::{de::DeserializeOwned, Serialize};
 
-use crate::error::{self, Error, HttpError};
+type StandardBodyType = String;
+type GenericRequest = Request<StandardBodyType>;
+type GenericResponse = Response<StandardBodyType>;
+type BoxedHandler = Box<dyn Fn(GenericRequest) -> Pin<Box<dyn Future<Output = GenericResponse>>>>;
+type RefHandler<'a> = &'a dyn Fn(GenericRequest) -> Pin<Box<dyn Future<Output = GenericResponse>>>;
 
-#[allow(dead_code)]
-type HandlerResult<T> = Result<T, HttpError>;
-#[allow(dead_code)]
-pub type HttpResult<T> = HandlerResult<Response<T>>;
-type InternalResult<T> = Result<T, Error>;
-pub type GenericHttpResponse = InternalResult<Response<String>>;
-
-pub type BoxedAsyncHandler = Box<
-    dyn 'static + Fn(LocalGenericHttpRequest) -> Pin<Box<dyn Future<Output = GenericHttpResponse>>>,
->;
-
-#[allow(dead_code)]
-pub type RefAsyncHandler<'a> =
-    &'a dyn Fn(
-        RequestWrapper<String>,
-    ) -> Pin<Box<dyn Future<Output = Result<Response<String>, Error>>>>;
-
-type LocalGenericHttpRequest = RequestWrapper<String>;
-
-#[async_trait]
-pub trait RealRunner<Input, Output, Extractor, BodyType>: Clone + Sync + Send {
-    async fn run(&self, req: LocalGenericHttpRequest) -> GenericHttpResponse;
+#[derive(Debug)]
+pub struct SerdeError {
+    body: String,
 }
 
-pub trait CRunner<Input, Output, Extractor, BodyType> {
-    fn create_runner(&'static self, _extractor: &Extractor) -> BoxedAsyncHandler;
-}
-
-#[async_trait]
-impl<BodyType, Extractor, Req, Res, FFut, F> RealRunner<Req, Res, Extractor, BodyType> for F
-where
-    F: Fn(Req) -> FFut + Clone + Sync + Send,
-    FFut: Future<Output = Res> + Send,
-    Req: TryFromWithExtractor<Extractor, BodyType, Req> + Send,
-    Res: Into<GenericHttpResponse>,
-{
-    async fn run(&self, req: LocalGenericHttpRequest) -> GenericHttpResponse {
-        self(Req::try_from(req)?).await.into()
+impl SerdeError {
+    pub fn new(body: String) -> Self {
+        Self { body }
     }
 }
 
-impl<Req, Res, BodyType, Extractor, F> CRunner<Req, Res, Extractor, BodyType> for F
-where
-    F: RealRunner<Req, Res, Extractor, BodyType> + 'static,
-{
-    #[allow(unused_variables)]
-    fn create_runner(&'static self, extractor: &Extractor) -> BoxedAsyncHandler {
-        Box::new(move |req: LocalGenericHttpRequest| Box::pin(async { self.run(req).await }))
+pub struct Request<T> {
+    body: T,
+}
+
+type Result<T> = std::result::Result<T, SerdeError>;
+
+impl<T> Request<T> {
+    fn new(value: T) -> Self {
+        Self { body: value }
+    }
+
+    fn body(&self) -> &T {
+        &self.body
+    }
+
+    // TODO: Valuate if this will keep this fn or move to an from_parts style
+    fn and_then<BodyType>(
+        self,
+        callback: impl FnOnce(T) -> Result<BodyType>,
+    ) -> Result<Request<BodyType>> {
+        let body = self.body;
+        callback(body).map(Request::<BodyType>::new)
     }
 }
 
-pub struct RequestWrapper<Body> {
-    request: Request<Body>,
+pub struct Response<T> {
+    body: T,
 }
 
-impl<Body> RequestWrapper<Body> {
-    pub fn new(data: Body) -> Self {
-        Self {
-            request: Request::new(data),
-        }
+impl<T> Response<T> {
+    fn new(value: T) -> Self {
+        Self { body: value }
+    }
+
+    fn body(&self) -> &T {
+        &self.body
+    }
+
+    // TODO: Valuate if this will keep this fn or move to an from_parts style
+    fn and_then<BodyType>(
+        self,
+        callback: impl FnOnce(T) -> Result<BodyType>,
+    ) -> Result<Response<BodyType>> {
+        let body = self.body;
+        callback(body).map(Response::<BodyType>::new)
     }
 }
 
-pub trait BodyExtractors {
+trait BodyDeserializer {
     type Item: DeserializeOwned;
-    fn extract(content: String) -> Result<Self::Item, String>;
+
+    fn deserialize(content: &StandardBodyType) -> Result<Self::Item>
+    where
+        Self: std::marker::Sized;
 }
 
-#[derive(Clone, Copy)]
+trait BodySerializer {
+    type Item: Serialize;
+
+    fn serialize(content: &Self::Item) -> Result<StandardBodyType>;
+}
+
+/// Describes a type that can be extracted using a BodyExtractors
+pub trait RunnerInput<Extractor> {
+    fn try_into(input: Request<StandardBodyType>) -> Result<Self>
+    where
+        Self: std::marker::Sized;
+}
+
+impl<BodyType, Extractor> RunnerInput<Extractor> for BodyType
+where
+    Extractor: BodyDeserializer<Item = BodyType>,
+    BodyType: DeserializeOwned,
+{
+    fn try_into(input: Request<String>) -> Result<Self>
+    where
+        Self: std::marker::Sized,
+    {
+        Extractor::deserialize(input.body())
+    }
+}
+
+impl<BodyType, Extractor> RunnerInput<Extractor> for Request<BodyType>
+where
+    Extractor: BodyDeserializer<Item = BodyType>,
+    BodyType: DeserializeOwned,
+{
+    fn try_into(input: Request<String>) -> Result<Self>
+    where
+        Self: std::marker::Sized,
+    {
+        input.and_then(|body| Extractor::deserialize(&body))
+    }
+}
+
+pub trait RunnerOutput<Serializer> {
+    fn try_into(self) -> Result<Response<String>>;
+}
+
+impl<BodyType, Serializer> RunnerOutput<Serializer> for Response<BodyType>
+where
+    Serializer: BodySerializer<Item = BodyType>,
+    BodyType: Serialize,
+{
+    fn try_into(self) -> Result<Response<String>> {
+        self.and_then(|body| Serializer::serialize(&body))
+    }
+}
+
+impl<BodyType, Serializer> RunnerOutput<Serializer> for BodyType
+where
+    Serializer: BodySerializer<Item = BodyType>,
+    BodyType: Serialize,
+{
+    fn try_into(self) -> Result<Response<String>> {
+        Serializer::serialize(&self).map(Response::new)
+    }
+}
+
+#[async_trait]
+pub trait Runner<Input, Output>: Clone + Send + Sync {
+    async fn call_runner(
+        &self,
+        run: Request<StandardBodyType>,
+    ) -> Result<Response<StandardBodyType>>;
+}
+
+#[async_trait]
+impl<ReqBody, ResBody, FnIn, FnOut, BodyDes, BodySer, Fut, F>
+    Runner<(FnIn, BodyDes), (FnOut, BodySer)> for F
+where
+    F: Fn(FnIn) -> Fut + Send + Sync + Clone,
+    Fut: Future<Output = FnOut> + Send,
+    FnIn: RunnerInput<BodyDes> + Send,
+    BodyDes: BodyDeserializer<Item = ReqBody>,
+    ReqBody: DeserializeOwned,
+    FnOut: RunnerOutput<BodySer>,
+    BodySer: BodySerializer<Item = ResBody>,
+    ResBody: Serialize,
+{
+    async fn call_runner(&self, inp: Request<String>) -> Result<Response<String>> {
+        FnOut::try_into(self(FnIn::try_into(inp)?).await)
+    }
+}
+
+#[async_trait]
+impl<ResBody, FnOut, BodySer, Fut, F> Runner<((), ()), (FnOut, BodySer)> for F
+where
+    F: Fn() -> Fut + Send + Sync + Clone,
+    Fut: Future<Output = FnOut> + Send,
+    FnOut: RunnerOutput<BodySer>,
+    BodySer: BodySerializer<Item = ResBody>,
+    ResBody: Serialize,
+{
+    async fn call_runner(&self, _inp: Request<String>) -> Result<Response<String>> {
+        FnOut::try_into(self().await)
+    }
+}
+
 pub struct Json<T>(PhantomData<T>);
 
-impl<T> BodyExtractors for Json<T>
+impl<T> Json<T> {
+    fn new() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<T> BodyDeserializer for Json<T>
 where
     T: DeserializeOwned,
 {
     type Item = T;
 
-    fn extract(content: String) -> Result<Self::Item, String> {
-        let deserialized = serde_json::from_str(content.as_str());
-        deserialized.map_err(|err| err.to_string())
+    fn deserialize(content: &StandardBodyType) -> Result<Self::Item>
+    where
+        Self: std::marker::Sized,
+    {
+        serde_json::from_str(content).map_err(|err| SerdeError {
+            body: err.to_string(),
+        })
     }
 }
 
-impl<T> Json<T> {
-    #[allow(dead_code)]
-    pub fn new() -> Self {
-        Self(PhantomData)
-    }
-}
-
-pub trait TryFromWithExtractor<WithExtractor, BodyType, OutputType> {
-    fn try_from(value: LocalGenericHttpRequest) -> Result<OutputType, error::Error>;
-}
-
-impl<Req, Extractor> TryFromWithExtractor<Extractor, Req, Req> for Req
+impl<T> BodySerializer for Json<T>
 where
-    Extractor: BodyExtractors<Item = Req>,
-    Req: DeserializeOwned,
+    T: Serialize,
 {
-    fn try_from(value: LocalGenericHttpRequest) -> Result<Req, error::Error> {
-        let body = value.request.into_body();
-        Extractor::extract(body).map_err(error::Error::ParseBody)
+    type Item = T;
+
+    fn serialize(content: &Self::Item) -> Result<String> {
+        serde_json::to_string(content).map_err(|err| SerdeError {
+            body: err.to_string(),
+        })
     }
 }
 
-impl<Req, Extractor> TryFromWithExtractor<Extractor, Req, Request<Req>> for Request<Req>
+fn encapsulate_runner<FnInput, FnOutput, Deserializer, Serializer, R>(
+    runner: R,
+    _deserializer: &Deserializer,
+    _serializer: &Serializer,
+) -> impl Fn(Request<String>) -> Pin<Box<dyn Future<Output = Result<Response<String>>>>>
 where
-    Extractor: BodyExtractors<Item = Req>,
-    Req: DeserializeOwned,
+    R: Runner<(FnInput, Deserializer), (FnOutput, Serializer)> + 'static,
+    Deserializer: 'static,
+    Serializer: 'static,
+    FnInput: 'static,
+    FnOutput: 'static,
 {
-    fn try_from(value: LocalGenericHttpRequest) -> Result<Request<Req>, error::Error> {
-        let (parts, body) = value.request.into_parts();
-        Extractor::extract(body)
-            .map(|result| Request::from_parts(parts, result))
-            .map_err(error::Error::ParseBody)
-    }
+    move |request| Box::pin(call_runner(runner.clone(), request))
 }
 
-mod improv {
-    use std::{marker::PhantomData, pin::Pin};
-
-    use async_trait::async_trait;
-    use futures::Future;
-    use serde::{de::DeserializeOwned, Serialize};
-
-    #[derive(Debug)]
-    pub struct SerdeError {
-        body: String,
-    }
-
-    impl SerdeError {
-        pub fn new(body: String) -> Self {
-            Self { body }
-        }
-    }
-
-    pub struct Request<T> {
-        body: T,
-    }
-
-    type Result<T> = std::result::Result<T, SerdeError>;
-
-    impl<T> Request<T> {
-        fn new(value: T) -> Self {
-            Self { body: value }
-        }
-
-        fn body(&self) -> &T {
-            &self.body
-        }
-
-        // TODO: Valuate if this will keep this fn or move to an from_parts style
-        fn and_then<BodyType>(
-            self,
-            callback: impl FnOnce(T) -> Result<BodyType>,
-        ) -> Result<Request<BodyType>> {
-            let body = self.body;
-            callback(body).map(Request::<BodyType>::new)
-        }
-    }
-
-    pub struct Response<T> {
-        body: T,
-    }
-
-    impl<T> Response<T> {
-        fn new(value: T) -> Self {
-            Self { body: value }
-        }
-
-        fn body(&self) -> &T {
-            &self.body
-        }
-
-        // TODO: Valuate if this will keep this fn or move to an from_parts style
-        fn and_then<BodyType>(
-            self,
-            callback: impl FnOnce(T) -> Result<BodyType>,
-        ) -> Result<Response<BodyType>> {
-            let body = self.body;
-            callback(body).map(Response::<BodyType>::new)
-        }
-    }
-
-    type StandardBodyType = String;
-
-    trait BodyDeserializer {
-        type Item: DeserializeOwned;
-
-        fn deserialize(content: &StandardBodyType) -> Result<Self::Item>
-        where
-            Self: std::marker::Sized;
-    }
-
-    trait BodySerializer {
-        type Item: Serialize;
-
-        fn serialize(content: &Self::Item) -> Result<StandardBodyType>;
-    }
-
-    /// Describes a type that can be extracted using a BodyExtractors
-    pub trait RunnerInput<Extractor> {
-        fn try_into(input: Request<StandardBodyType>) -> Result<Self>
-        where
-            Self: std::marker::Sized;
-    }
-
-    impl<BodyType, Extractor> RunnerInput<Extractor> for BodyType
-    where
-        Extractor: BodyDeserializer<Item = BodyType>,
-        BodyType: DeserializeOwned,
-    {
-        fn try_into(input: Request<String>) -> Result<Self>
-        where
-            Self: std::marker::Sized,
-        {
-            Extractor::deserialize(input.body())
-        }
-    }
-
-    impl<BodyType, Extractor> RunnerInput<Extractor> for Request<BodyType>
-    where
-        Extractor: BodyDeserializer<Item = BodyType>,
-        BodyType: DeserializeOwned,
-    {
-        fn try_into(input: Request<String>) -> Result<Self>
-        where
-            Self: std::marker::Sized,
-        {
-            input.and_then(|body| Extractor::deserialize(&body))
-        }
-    }
-
-    pub trait RunnerOutput<Serializer> {
-        fn try_into(self) -> Result<Response<String>>;
-    }
-
-    impl<BodyType, Serializer> RunnerOutput<Serializer> for Response<BodyType>
-    where
-        Serializer: BodySerializer<Item = BodyType>,
-        BodyType: Serialize,
-    {
-        fn try_into(self) -> Result<Response<String>> {
-            self.and_then(|body| Serializer::serialize(&body))
-        }
-    }
-
-    impl<BodyType, Serializer> RunnerOutput<Serializer> for BodyType
-    where
-        Serializer: BodySerializer<Item = BodyType>,
-        BodyType: Serialize,
-    {
-        fn try_into(self) -> Result<Response<String>> {
-            Serializer::serialize(&self).map(Response::new)
-        }
-    }
-
-    #[async_trait]
-    pub trait Runner<Input, Output>: Clone + Send + Sync {
-        async fn call_runner(
-            &self,
-            run: Request<StandardBodyType>,
-        ) -> Result<Response<StandardBodyType>>;
-    }
-
-    #[async_trait]
-    impl<ReqBody, ResBody, FnIn, FnOut, BodyDes, BodySer, Fut, F>
-        Runner<(FnIn, BodyDes), (FnOut, BodySer)> for F
-    where
-        F: Fn(FnIn) -> Fut + Send + Sync + Clone,
-        Fut: Future<Output = FnOut> + Send,
-        FnIn: RunnerInput<BodyDes> + Send,
-        BodyDes: BodyDeserializer<Item = ReqBody>,
-        ReqBody: DeserializeOwned,
-        FnOut: RunnerOutput<BodySer>,
-        BodySer: BodySerializer<Item = ResBody>,
-        ResBody: Serialize,
-    {
-        async fn call_runner(&self, inp: Request<String>) -> Result<Response<String>> {
-            FnOut::try_into(self(FnIn::try_into(inp)?).await)
-        }
-    }
-
-    #[async_trait]
-    impl<ResBody, FnOut, BodySer, Fut, F> Runner<((), ()), (FnOut, BodySer)> for F
-    where
-        F: Fn() -> Fut + Send + Sync + Clone,
-        Fut: Future<Output = FnOut> + Send,
-        FnOut: RunnerOutput<BodySer>,
-        BodySer: BodySerializer<Item = ResBody>,
-        ResBody: Serialize,
-    {
-        async fn call_runner(&self, _inp: Request<String>) -> Result<Response<String>> {
-            FnOut::try_into(self().await)
-        }
-    }
-
-    struct Json<T>(PhantomData<T>);
-
-    impl<T> BodyDeserializer for Json<T>
-    where
-        T: DeserializeOwned,
-    {
-        type Item = T;
-
-        fn deserialize(content: &StandardBodyType) -> Result<Self::Item>
-        where
-            Self: std::marker::Sized,
-        {
-            serde_json::from_str(content).map_err(|err| SerdeError {
-                body: err.to_string(),
-            })
-        }
-    }
-
-    impl<T> BodySerializer for Json<T>
-    where
-        T: Serialize,
-    {
-        type Item = T;
-
-        fn serialize(content: &Self::Item) -> Result<String> {
-            serde_json::to_string(content).map_err(|err| SerdeError {
-                body: err.to_string(),
-            })
-        }
-    }
-
-    fn encapsulate_runner<FnInput, FnOutput, Deserializer, Serializer, R>(
-        runner: R,
-        _deserializer: &Deserializer,
-        _serializer: &Serializer,
-    ) -> impl Fn(Request<String>) -> Pin<Box<dyn Future<Output = Result<Response<String>>>>>
-    where
-        R: Runner<(FnInput, Deserializer), (FnOutput, Serializer)> + 'static,
-        Deserializer: 'static,
-        Serializer: 'static,
-        FnInput: 'static,
-        FnOutput: 'static,
-    {
-        move |request| Box::pin(call_runner(runner.clone(), request))
-    }
-
-    async fn call_runner<FnInput, FnOutput, Deserializer, Serializer, R>(
-        runner: R,
-        req: Request<String>,
-    ) -> Result<Response<String>>
-    where
-        R: Runner<(FnInput, Deserializer), (FnOutput, Serializer)>,
-    {
-        runner.call_runner(req).await
-    }
-
-    #[cfg(test)]
-    mod improv_tests {
-        use std::marker::PhantomData;
-
-        use async_std_test::async_test;
-        use serde::{Deserialize, Serialize};
-
-        use crate::handler::improv::Json;
-
-        use super::{encapsulate_runner, Request, Response};
-
-        #[derive(Deserialize, Serialize)]
-        struct SomeBodyType {
-            field: String,
-        }
-
-        async fn simple_handler(input: Request<SomeBodyType>) -> Response<SomeBodyType> {
-            let mut new_field = input.body().field.to_owned();
-            new_field.push_str(" - Ed Sheeran");
-
-            Response::new(SomeBodyType { field: new_field })
-        }
-
-        async fn unit_handler() -> Response<SomeBodyType> {
-            let new_field = String::from("HOPE - NF");
-
-            Response::new(SomeBodyType { field: new_field })
-        }
-
-        async fn simple_handler_with_body(input: SomeBodyType) -> Response<SomeBodyType> {
-            let mut new_field = input.field;
-            new_field.push_str(" - Halsey");
-
-            Response::new(SomeBodyType { field: new_field })
-        }
-
-        async fn handler_with_simple_body_on_input_and_output(input: SomeBodyType) -> SomeBodyType {
-            let mut new_field = input.field;
-            new_field.push_str(" - Imagine Dragons");
-
-            SomeBodyType { field: new_field }
-        }
-
-        #[async_test]
-        async fn test_simple_handler_implements_runner() -> std::io::Result<()> {
-            let a = encapsulate_runner(simple_handler, &Json(PhantomData), &Json(PhantomData));
-            let b = a(Request {
-                body: serde_json::json!({ "field": "South of the border" }).to_string(),
-            })
-            .await;
-
-            assert_eq!(
-                b.unwrap().body().as_str(),
-                serde_json::json!({ "field": "South of the border - Ed Sheeran"  }).to_string()
-            );
-
-            Ok(())
-        }
-
-        #[async_test]
-        async fn test_unit_handler_implements_runner() -> std::io::Result<()> {
-            let a = encapsulate_runner(unit_handler, &(), &Json(PhantomData));
-            let b = a(Request {
-                body: serde_json::json!({ "field": "South of the border" }).to_string(),
-            })
-            .await;
-
-            let expected_field_result = "HOPE - NF";
-
-            assert_eq!(
-                b.unwrap().body().as_str(),
-                serde_json::json!({ "field": expected_field_result }).to_string()
-            );
-
-            Ok(())
-        }
-
-        #[async_test]
-        async fn test_simple_handler_with_body_implements_runner() -> std::io::Result<()> {
-            let a = encapsulate_runner(
-                simple_handler_with_body,
-                &Json(PhantomData),
-                &Json(PhantomData),
-            );
-            let b = a(Request {
-                body: serde_json::json!({ "field": "So Good" }).to_string(),
-            })
-            .await;
-
-            let expected_field_result = "So Good - Halsey";
-
-            assert_eq!(
-                b.unwrap().body().as_str(),
-                serde_json::json!({ "field": expected_field_result }).to_string()
-            );
-
-            Ok(())
-        }
-
-        #[async_test]
-        async fn test_handler_with_simple_body_on_input_and_output_runner() -> std::io::Result<()> {
-            let a = encapsulate_runner(
-                handler_with_simple_body_on_input_and_output,
-                &Json(PhantomData),
-                &Json(PhantomData),
-            );
-            let b = a(Request {
-                body: serde_json::json!({ "field": "Sharks" }).to_string(),
-            })
-            .await;
-
-            let expected_field_result = "Sharks - Imagine Dragons";
-
-            assert_eq!(
-                b.unwrap().body().as_str(),
-                serde_json::json!({ "field": expected_field_result }).to_string()
-            );
-
-            Ok(())
-        }
-    }
+async fn call_runner<FnInput, FnOutput, Deserializer, Serializer, R>(
+    runner: R,
+    req: Request<String>,
+) -> Result<Response<String>>
+where
+    R: Runner<(FnInput, Deserializer), (FnOutput, Serializer)>,
+{
+    runner.call_runner(req).await
 }
 
 #[cfg(test)]
-mod async_runner {
+mod tests {
+    use std::marker::PhantomData;
 
     use async_std_test::async_test;
+    use serde::{Deserialize, Serialize};
 
-    use http::{Request, Response};
-    use serde::Deserialize;
+    use crate::handler::Json;
 
-    use super::{CRunner, GenericHttpResponse, Json, RequestWrapper};
+    use super::{encapsulate_runner, Request, Response};
 
-    #[derive(Deserialize)]
+    #[derive(Deserialize, Serialize)]
     struct SomeBodyType {
-        _correct: bool,
+        field: String,
     }
 
-    async fn runner_with_request(_req: Request<SomeBodyType>) -> GenericHttpResponse {
-        Ok(Response::new(
-            serde_json::json!({"other_new_structure": true}).to_string(),
-        ))
+    async fn simple_handler(input: Request<SomeBodyType>) -> Response<SomeBodyType> {
+        let mut new_field = input.body().field.to_owned();
+        new_field.push_str(" - Ed Sheeran");
+
+        Response::new(SomeBodyType { field: new_field })
     }
 
-    async fn runner_with_simple_struct(_req: SomeBodyType) -> GenericHttpResponse {
-        Ok(Response::new(
-            serde_json::json!({"new_structure": true}).to_string(),
-        ))
+    async fn unit_handler() -> Response<SomeBodyType> {
+        let new_field = String::from("HOPE - NF");
+
+        Response::new(SomeBodyType { field: new_field })
+    }
+
+    async fn simple_handler_with_body(input: SomeBodyType) -> Response<SomeBodyType> {
+        let mut new_field = input.field;
+        new_field.push_str(" - Halsey");
+
+        Response::new(SomeBodyType { field: new_field })
+    }
+
+    async fn handler_with_simple_body_on_input_and_output(input: SomeBodyType) -> SomeBodyType {
+        let mut new_field = input.field;
+        new_field.push_str(" - Imagine Dragons");
+
+        SomeBodyType { field: new_field }
     }
 
     #[async_test]
-    async fn test_runner_works() -> std::io::Result<()> {
-        let body = serde_json::json!({"_correct": false}).to_string();
-        let request = RequestWrapper {
-            request: Request::new(body.clone()),
-        };
-
-        let request2 = RequestWrapper {
-            request: Request::new(body),
-        };
-
-        let handler1 = runner_with_simple_struct.create_runner(&Json::new());
-        let handler2 = runner_with_request.create_runner(&Json::new());
+    async fn test_simple_handler_implements_runner() -> std::io::Result<()> {
+        let a = encapsulate_runner(simple_handler, &Json(PhantomData), &Json(PhantomData));
+        let b = a(Request {
+            body: serde_json::json!({ "field": "South of the border" }).to_string(),
+        })
+        .await;
 
         assert_eq!(
-            handler1(request).await.unwrap().into_body(),
-            serde_json::json!({"new_structure": true}).to_string()
+            b.unwrap().body().as_str(),
+            serde_json::json!({ "field": "South of the border - Ed Sheeran"  }).to_string()
         );
 
+        Ok(())
+    }
+
+    #[async_test]
+    async fn test_unit_handler_implements_runner() -> std::io::Result<()> {
+        let a = encapsulate_runner(unit_handler, &(), &Json(PhantomData));
+        let b = a(Request {
+            body: serde_json::json!({ "field": "South of the border" }).to_string(),
+        })
+        .await;
+
+        let expected_field_result = "HOPE - NF";
+
         assert_eq!(
-            handler2(request2).await.unwrap().into_body(),
-            serde_json::json!({"other_new_structure": true}).to_string()
+            b.unwrap().body().as_str(),
+            serde_json::json!({ "field": expected_field_result }).to_string()
+        );
+
+        Ok(())
+    }
+
+    #[async_test]
+    async fn test_simple_handler_with_body_implements_runner() -> std::io::Result<()> {
+        let a = encapsulate_runner(
+            simple_handler_with_body,
+            &Json(PhantomData),
+            &Json(PhantomData),
+        );
+        let b = a(Request {
+            body: serde_json::json!({ "field": "So Good" }).to_string(),
+        })
+        .await;
+
+        let expected_field_result = "So Good - Halsey";
+
+        assert_eq!(
+            b.unwrap().body().as_str(),
+            serde_json::json!({ "field": expected_field_result }).to_string()
+        );
+
+        Ok(())
+    }
+
+    #[async_test]
+    async fn test_handler_with_simple_body_on_input_and_output_runner() -> std::io::Result<()> {
+        let a = encapsulate_runner(
+            handler_with_simple_body_on_input_and_output,
+            &Json(PhantomData),
+            &Json(PhantomData),
+        );
+        let b = a(Request {
+            body: serde_json::json!({ "field": "Sharks" }).to_string(),
+        })
+        .await;
+
+        let expected_field_result = "Sharks - Imagine Dragons";
+
+        assert_eq!(
+            b.unwrap().body().as_str(),
+            serde_json::json!({ "field": expected_field_result }).to_string()
         );
 
         Ok(())

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -329,6 +329,30 @@ mod improv {
         }
     }
 
+    fn encapsulate_runner<FnInput, FnOutput, Deserializer, Serializer, R>(
+        runner: R,
+        _deserializer: &Deserializer,
+        _serializer: &Serializer,
+    ) -> impl Fn(Request<String>) -> Pin<Box<dyn Future<Output = Result<Response<String>>>>>
+    where
+        R: Runner<(FnInput, Deserializer), (FnOutput, Serializer)> + 'static,
+        Deserializer: 'static,
+        Serializer: 'static,
+        FnInput: 'static,
+        FnOutput: 'static,
+    {
+        move |request| Box::pin(call_runner(runner.clone(), request))
+    }
+
+    async fn call_runner<FnInput, FnOutput, Deserializer, Serializer, R>(
+        runner: R,
+        req: Request<String>,
+    ) -> Result<Response<String>>
+    where
+        R: Runner<(FnInput, Deserializer), (FnOutput, Serializer)>,
+    {
+        runner.call_runner(req).await
+    }
 }
 
 #[cfg(test)]

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -237,6 +237,26 @@ mod improv {
     pub trait RunnerOutput<Serializer> {
         fn try_into(self) -> Result<Response<String>>;
     }
+
+    impl<BodyType, Serializer> RunnerOutput<Serializer> for Response<BodyType>
+    where
+        Serializer: BodySerializer<Item = BodyType>,
+        BodyType: Serialize,
+    {
+        fn try_into(self) -> Result<Response<String>> {
+            self.and_then(|body| Serializer::serialize(&body))
+        }
+    }
+
+    impl<BodyType, Serializer> RunnerOutput<Serializer> for BodyType
+    where
+        Serializer: BodySerializer<Item = BodyType>,
+        BodyType: Serialize,
+    {
+        fn try_into(self) -> Result<Response<String>> {
+            Serializer::serialize(&self).map(Response::new)
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -297,6 +297,38 @@ mod improv {
             FnOut::try_into(self().await)
         }
     }
+
+    struct Json<T>(PhantomData<T>);
+
+    impl<T> BodyDeserializer for Json<T>
+    where
+        T: DeserializeOwned,
+    {
+        type Item = T;
+
+        fn deserialize(content: &StandardBodyType) -> Result<Self::Item>
+        where
+            Self: std::marker::Sized,
+        {
+            serde_json::from_str(content).map_err(|err| SerdeError {
+                body: err.to_string(),
+            })
+        }
+    }
+
+    impl<T> BodySerializer for Json<T>
+    where
+        T: Serialize,
+    {
+        type Item = T;
+
+        fn serialize(content: &Self::Item) -> Result<String> {
+            serde_json::to_string(content).map_err(|err| SerdeError {
+                body: err.to_string(),
+            })
+        }
+    }
+
 }
 
 #[cfg(test)]

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -184,6 +184,32 @@ mod improv {
             callback(body).map(Response::<BodyType>::new)
         }
     }
+
+    type StandardBodyType = String;
+
+    trait BodyDeserializer {
+        type Item: DeserializeOwned;
+
+        fn deserialize(content: &StandardBodyType) -> Result<Self::Item>
+        where
+            Self: std::marker::Sized;
+    }
+
+    trait BodySerializer {
+        type Item: Serialize;
+
+        fn serialize(content: &Self::Item) -> Result<StandardBodyType>;
+    }
+
+    /// Describes a type that can be extracted using a BodyExtractors
+    pub trait RunnerInput<Extractor> {
+        fn try_into(input: Request<StandardBodyType>) -> Result<Self>
+        where
+            Self: std::marker::Sized;
+    }
+    pub trait RunnerOutput<Serializer> {
+        fn try_into(self) -> Result<Response<String>>;
+    }
 }
 
 #[cfg(test)]

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -257,6 +257,14 @@ mod improv {
             Serializer::serialize(&self).map(Response::new)
         }
     }
+
+    #[async_trait]
+    pub trait Runner<Input, Output>: Clone + Send + Sync {
+        async fn call_runner(
+            &self,
+            run: Request<StandardBodyType>,
+        ) -> Result<Response<StandardBodyType>>;
+    }
 }
 
 #[cfg(test)]

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -207,6 +207,33 @@ mod improv {
         where
             Self: std::marker::Sized;
     }
+
+    impl<BodyType, Extractor> RunnerInput<Extractor> for BodyType
+    where
+        Extractor: BodyDeserializer<Item = BodyType>,
+        BodyType: DeserializeOwned,
+    {
+        fn try_into(input: Request<String>) -> Result<Self>
+        where
+            Self: std::marker::Sized,
+        {
+            Extractor::deserialize(input.body())
+        }
+    }
+
+    impl<BodyType, Extractor> RunnerInput<Extractor> for Request<BodyType>
+    where
+        Extractor: BodyDeserializer<Item = BodyType>,
+        BodyType: DeserializeOwned,
+    {
+        fn try_into(input: Request<String>) -> Result<Self>
+        where
+            Self: std::marker::Sized,
+        {
+            input.and_then(|body| Extractor::deserialize(&body))
+        }
+    }
+
     pub trait RunnerOutput<Serializer> {
         fn try_into(self) -> Result<Response<String>>;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,12 @@
 mod error;
 mod handle_selector;
 mod handler;
+mod request;
+mod response;
 
-use crate::handler::{encapsulate_runner, Method, RefHandler, Runner};
+use crate::handler::{encapsulate_runner, RefHandler, Runner};
 use handle_selector::HandlerSelect;
+use request::Method;
 
 #[derive(Default)]
 pub struct Server<'a> {
@@ -191,7 +194,9 @@ mod tests {
     use serde::{Deserialize, Serialize};
 
     use crate::{
-        handler::{GenericResponse, Json, Method, Request, Response},
+        handler::{GenericResponse, Json},
+        request::{Method, Request},
+        response::Response,
         Server,
     };
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,0 +1,85 @@
+use crate::handler::Result;
+
+pub type Method = http::Method;
+pub type Uri = http::Uri;
+pub type HttpRequest<T> = http::Request<T>;
+pub type HttpBuilder = http::request::Builder;
+
+pub struct Request<T> {
+    request: HttpRequest<T>,
+}
+
+impl Request<()> {
+    pub fn builder() -> Builder {
+        Builder {
+            builder: HttpBuilder::new(),
+        }
+    }
+}
+
+impl<T> Request<T> {
+    pub fn new(value: T) -> Self {
+        Self {
+            request: HttpRequest::new(value),
+        }
+    }
+
+    pub fn body(&self) -> &T {
+        self.request.body()
+    }
+
+    // TODO: Valuate if this will keep this fn or move to an from_parts style
+    pub fn and_then<BodyType>(
+        self,
+        callback: impl FnOnce(T) -> Result<BodyType>,
+    ) -> Result<Request<BodyType>> {
+        let (parts, body) = self.request.into_parts();
+        callback(body).map(|body| Request {
+            request: HttpRequest::from_parts(parts, body),
+        })
+    }
+
+    pub fn method(&self) -> &Method {
+        self.request.method()
+    }
+
+    pub fn method_mut(&mut self) -> &mut Method {
+        self.request.method_mut()
+    }
+
+    pub fn uri(&self) -> &Uri {
+        self.request.uri()
+    }
+
+    pub fn uri_mut(&mut self) -> &mut Uri {
+        self.request.uri_mut()
+    }
+}
+
+pub struct Builder {
+    pub builder: HttpBuilder,
+}
+
+impl Builder {
+    pub fn uri<T>(self, uri: T) -> Builder
+    where
+        Uri: TryFrom<T>,
+        <Uri as TryFrom<T>>::Error: Into<http::Error>,
+    {
+        Self {
+            builder: self.builder.uri(uri),
+        }
+    }
+
+    pub fn body<T>(self, body: T) -> Request<T> {
+        Request {
+            request: self.builder.body(body).unwrap(),
+        }
+    }
+
+    pub fn method(self, method: Method) -> Self {
+        Self {
+            builder: self.builder.method(method),
+        }
+    }
+}

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,9 +1,41 @@
 use crate::handler::Result;
 
 pub type HttpResponse<T> = http::Response<T>;
+type HttpResponseBuilder = http::response::Builder;
+type StatusCode = http::StatusCode;
+
+pub struct ResponseBuilder {
+    builder: HttpResponseBuilder,
+}
+
+impl ResponseBuilder {
+    pub fn status<T>(self, status: T) -> ResponseBuilder
+    where
+        StatusCode: TryFrom<T>,
+        <StatusCode as TryFrom<T>>::Error: Into<http::Error>,
+    {
+        ResponseBuilder {
+            builder: self.builder.status(status),
+        }
+    }
+
+    pub fn body<T>(self, body: T) -> Response<T> {
+        Response {
+            response: self.builder.body(body).unwrap(),
+        }
+    }
+}
 
 pub struct Response<T> {
     response: HttpResponse<T>,
+}
+
+impl Response<()> {
+    pub fn builder() -> ResponseBuilder {
+        ResponseBuilder {
+            builder: HttpResponseBuilder::new(),
+        }
+    }
 }
 
 impl<T> Response<T> {

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,0 +1,24 @@
+use crate::handler::Result;
+
+pub struct Response<T> {
+    body: T,
+}
+
+impl<T> Response<T> {
+    pub fn new(value: T) -> Self {
+        Self { body: value }
+    }
+
+    pub fn body(&self) -> &T {
+        &self.body
+    }
+
+    // TODO: Valuate if this will keep this fn or move to an from_parts style
+    pub fn and_then<BodyType>(
+        self,
+        callback: impl FnOnce(T) -> Result<BodyType>,
+    ) -> Result<Response<BodyType>> {
+        let body = self.body;
+        callback(body).map(Response::<BodyType>::new)
+    }
+}

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,16 +1,20 @@
 use crate::handler::Result;
 
+pub type HttpResponse<T> = http::Response<T>;
+
 pub struct Response<T> {
-    body: T,
+    response: HttpResponse<T>,
 }
 
 impl<T> Response<T> {
     pub fn new(value: T) -> Self {
-        Self { body: value }
+        Self {
+            response: HttpResponse::new(value),
+        }
     }
 
     pub fn body(&self) -> &T {
-        &self.body
+        self.response.body()
     }
 
     // TODO: Valuate if this will keep this fn or move to an from_parts style
@@ -18,7 +22,9 @@ impl<T> Response<T> {
         self,
         callback: impl FnOnce(T) -> Result<BodyType>,
     ) -> Result<Response<BodyType>> {
-        let body = self.body;
-        callback(body).map(Response::<BodyType>::new)
+        let (parts, body) = self.response.into_parts();
+        callback(body).map(|body| Response {
+            response: HttpResponse::from_parts(parts, body),
+        })
     }
 }


### PR DESCRIPTION
## About

As It's now laid out, using an external HTTP library makes the traits exceptionally complicated and full of generics. To fulfill the need to accept these function signatures as Runners:
```rust
async fn name(request: Request<SomeBodyType>) -> Response<SomeOtherBodyType>;
async fn name(request: SomeBodyType) -> Response<SomeOtherBodyType>;
async fn name(request: Request<SomeBodyType>) -> SomeOtherBodyType;
async fn name(request: SomeBodyType) -> SomeOtherBodyType;
async fn name() -> SomeOtherBodyType;
async fn name() -> Response<SomeOtherBodyType>;
```

The Runner trait and the traits that it is based on were rewritten to be more concise and with fewer generics.\
Now the trait hierarchy follows:

```mermaid
graph TD;
  Runner --> RunnerInput;
  Runner --> RunnerOutput;
  RunnerInput --> BodyDeserializer;
  RunnerOutput --> BodySerializer;
```

Where RunnerInput defines which types are accepted as arguments of a Runner, same for RunnerOutput.\
So a Runner is a function that receives as arguments one or more multiple RunnerInput and returns a RunnerOutput.

This structure allows easy extension of serializer, deserializer, runner input, runner output, and function signatures, as creating one is just implementing a trait for a type. This allows the user to tailor the usage of the framework API to its needs.

### Task List

- [X] Create new traits
- [X] Implement traits
- [X] Implement a JSON BodySerializer and BodyDeserializer
- [X] Create tests validating that these functions are implementing the Runner
- [x] Replace old structure