### PR TITLE
Fix/listen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "handler"
+name = "yahf"
 version = "0.1.0"
 edition = "2021"
 

--- a/examples/hello_world/main.rs
+++ b/examples/hello_world/main.rs
@@ -1,0 +1,16 @@
+extern crate yahf;
+
+use yahf::server::Server;
+
+fn main() {
+    let mut a = Server::new();
+
+    a.get(
+        "/",
+        || async { "Hello world".to_string() },
+        &(),
+        &String::with_capacity(0),
+    );
+
+    a.listen("127.0.0.1:8000").unwrap();
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,3 +1,5 @@
+use std::{fmt::Display, sync::Arc};
+
 use crate::{
     handle_selector,
     handler::{encapsulate_runner, RefHandler, Runner},
@@ -30,7 +32,7 @@ pub struct Server<'a> {
     head: HandlerSelect<'a>,
 }
 
-impl<'a> Server<'a> {
+impl<'a: 'static> Server<'a> {
     pub fn new() -> Self {
         Self {
             get: HandlerSelect::new(),
@@ -349,29 +351,36 @@ impl<'a> Server<'a> {
         }
     }
 
-    pub fn listen<A: ToSocketAddrs>(&'static self, addr: A) -> ListenResult<()> {
+    pub fn listen<A: ToSocketAddrs + Display>(self, addr: A) -> ListenResult<()> {
         task::block_on(accept_loop(self, addr))
     }
 }
 type ListenResult<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
-async fn accept_loop(server: &'static Server<'_>, addr: impl ToSocketAddrs) -> ListenResult<()> {
+async fn accept_loop(
+    server: Server<'static>,
+    addr: impl ToSocketAddrs + Display,
+) -> ListenResult<()> {
+    let server = Arc::new(server);
     let listener = TcpListener::bind(addr).await.unwrap();
+    println!("Start listening on {}", listener.local_addr().unwrap());
     let mut incoming = listener.incoming();
 
     while let Some(stream) = incoming.next().await {
         let stream = stream?;
-        handle_stream(server, stream);
+        println!("Accepting from: {}", stream.peer_addr()?);
+        handle_stream(server.clone(), stream);
     }
     Ok(())
 }
 
 fn handle_stream(
-    server: &'static Server<'_>,
+    server: Arc<Server<'static>>,
     mut stream: TcpStream,
 ) -> async_std::task::JoinHandle<()> {
     task::spawn(async move {
-        if let Err(e) = connection_loop(server, &stream).await {
+        let fut = connection_loop(server, &stream);
+        if let Err(e) = fut.await {
             let formatted_error = format!("HTTP/1.1 {}", e);
             stream.write(formatted_error.as_bytes());
             eprintln!("{}", e);
@@ -384,7 +393,7 @@ const NOT_FOUND: &str = "404 Not Found";
 const HTTP_VERSION_NOT_SUPPORTED: &str = "505 HTTP Version Not Supported";
 
 async fn connection_loop(
-    server: &Server<'_>,
+    server: Arc<Server<'static>>,
     mut stream: impl AsyncRead + AsyncWrite + Unpin,
 ) -> ListenResult<()> {
     let buf_reader = BufReader::new(&mut stream);
@@ -415,8 +424,6 @@ async fn connection_loop(
         Method::CONNECT => method,
         _ => Err(BAD_REQUEST)?,
     };
-
-    println!("{}", method.as_str());
 
     let uri = match splitted_fl.next() {
         Some(mtd) => Uri::try_from(mtd).map_err(|_| BAD_REQUEST)?,
@@ -735,6 +742,8 @@ mod test_server {
 
 #[cfg(test)]
 mod test_connection_loop {
+    use std::sync::Arc;
+
     use async_std_test::async_test;
     use serde::{Deserialize, Serialize};
 
@@ -778,7 +787,7 @@ mod test_connection_loop {
         request: Request<String>,
     }
 
-    async fn run_test(server: &Server<'_>, test_config: TestConfig) {
+    async fn run_test(server: Arc<Server<'static>>, test_config: TestConfig) {
         // TODO: Implement ToString for Request
         let request = test_config.request;
         let response = test_config.response;
@@ -835,7 +844,9 @@ mod test_connection_loop {
             .body(serde_json::json!({"correct": true}).to_string());
         let test_config = TestConfig { request, response };
 
-        run_test(&server, test_config).await;
+        let server = Arc::new(server);
+
+        run_test(server, test_config).await;
 
         Ok(())
     }
@@ -866,7 +877,7 @@ mod test_connection_loop {
         Json::default()
     );
 
-    async fn test_for_error(server: &Server<'_>, request: String, response: String) {
+    async fn test_for_error(server: Arc<Server<'static>>, request: String, response: String) {
         // TODO: Implement ToString for Request
         let mut stream = MockTcpStream {
             read_data: request.into_bytes(),
@@ -890,10 +901,12 @@ mod test_connection_loop {
                 let mut server = Server::new();
                 server.all("/aaaaa", $fn, &$des, &Json::default());
 
+                let server = Arc::new(server);
+
                 let request = $send.to_owned();
                 let response = $expected.to_owned();
 
-                test_for_error(&server, request, response).await;
+                test_for_error(server.clone(), request, response).await;
 
                 Ok(())
             }


### PR DESCRIPTION
## About

- Fixed the request parsing for the case where there is no `body`;
- Change `Server` to require that any `path` registered to it be of `&'static str`;
- Add an `hello_world` example to help validate usage.