### PR TITLE
Feat/Middleware Factory

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -24,9 +24,21 @@ pub(crate) type InternalResult<T> = std::result::Result<T, Error>;
 
 pub struct Result<T>(InternalResult<T>);
 
+impl<T> Result<T> {
+    pub fn into_inner(self) -> InternalResult<T> {
+        self.0
+    }
+}
+
 impl<T> From<InternalResult<T>> for Result<T> {
     fn from(value: InternalResult<T>) -> Self {
         Result(value)
+    }
+}
+
+impl<T> From<Result<T>> for InternalResult<T> {
+    fn from(value: Result<T>) -> Self {
+        value.into_inner()
     }
 }
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -175,6 +175,17 @@ where
     }
 }
 
+impl BodyDeserializer for String {
+    type Item = String;
+
+    fn deserialize(_content: &StandardBodyType) -> Result<Self::Item>
+    where
+        Self: std::marker::Sized,
+    {
+        Ok(_content.to_owned())
+    }
+}
+
 impl BodySerializer for String {
     type Item = String;
 
@@ -183,11 +194,11 @@ impl BodySerializer for String {
     }
 }
 
-pub fn encapsulate_runner<FnInput, FnOutput, Deserializer, Serializer, R>(
+pub(crate) fn encapsulate_runner<FnInput, FnOutput, Deserializer, Serializer, R>(
     runner: R,
     _deserializer: &Deserializer,
     _serializer: &Serializer,
-) -> impl Fn(Request<String>) -> Pin<Box<dyn Future<Output = Response<String>> + Send>> + Sync + Send
+) -> impl Fn(Request<String>) -> Pin<Box<dyn Future<Output = Response<String>> + Send>> + Sync
 where
     R: Runner<(FnInput, Deserializer), (FnOutput, Serializer)> + 'static,
     Deserializer: 'static,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod error;
 pub mod handle_selector;
 pub mod handler;
+pub mod middleware;
 pub mod request;
 pub mod response;
 pub mod server;

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -1,0 +1,136 @@
+use std::sync::Arc;
+
+use futures::Future;
+
+use crate::{
+    handler::{encapsulate_runner, BoxedHandler, Runner},
+    request::Request,
+};
+
+pub trait PreMiddleware: Send + Sync + Clone {
+    type FutCallResponse;
+    fn call(&self, req: Request<String>) -> Self::FutCallResponse;
+}
+
+impl<MidFn, Fut> PreMiddleware for MidFn
+where
+    MidFn: Fn(Request<String>) -> Fut + Send + Sync + Clone,
+    Fut: Future<Output = Request<String>>,
+{
+    type FutCallResponse = Fut;
+    #[inline(always)]
+    fn call(&self, req: Request<String>) -> Self::FutCallResponse {
+        self(req)
+    }
+}
+
+impl<FPre, FAfter, F> MiddlewareFactory<FPre, FAfter>
+where
+    FPre: PreMiddleware<FutCallResponse = F> + 'static,
+    FAfter: 'static + Send + std::marker::Sync,
+    F: Future<Output = Request<String>> + Send,
+{
+    #[inline(always)]
+    pub fn pre<NewF: Future<Output = Request<String>>>(
+        self,
+        _before: &'static (impl PreMiddleware<FutCallResponse = NewF> + Sync),
+    ) -> MiddlewareFactory<
+        impl PreMiddleware<FutCallResponse = impl Future<Output = Request<String>>>,
+        FAfter,
+    > {
+        let pre = move |req| {
+            let cloned_pre_middleware = self.pre.clone();
+            async move {
+                let resp = cloned_pre_middleware.call(req).await;
+                _before.call(resp).await
+            }
+        };
+
+        MiddlewareFactory {
+            pre,
+            after: self.after,
+        }
+    }
+
+    pub fn build<R, FnInput, FnOutput, Deserializer, Serializer>(
+        self: Arc<Self>,
+        _runner: R,
+        _deserializer: &Deserializer,
+        _serializer: &Serializer,
+    ) -> BoxedHandler
+    where
+        R: Runner<(FnInput, Deserializer), (FnOutput, Serializer)> + 'static,
+    {
+        let handler = move |req| {
+            let pre = self.pre.clone();
+            let runner = _runner.clone();
+            async move {
+                let req_updated = pre.call(req).await;
+                let a = runner.call_runner(req_updated);
+                a.await
+            }
+        };
+
+        Box::new(encapsulate_runner(
+            handler,
+            &String::with_capacity(0),
+            &String::with_capacity(0),
+        ))
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct MiddlewareFactory<FPre, FAfter> {
+    pre: FPre,
+    after: FAfter,
+}
+
+impl MiddlewareFactory<(), ()> {
+    pub fn new() -> Self {
+        Self { pre: (), after: () }
+    }
+
+    pub fn pre<F: Future<Output = Request<String>>, UPM: PreMiddleware<FutCallResponse = F>>(
+        self,
+        pre: UPM,
+    ) -> MiddlewareFactory<UPM, ()> {
+        MiddlewareFactory { pre, after: () }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::sync::Arc;
+
+    use async_std_test::async_test;
+
+    use crate::{middleware::MiddlewareFactory, request::Request, response::Response};
+
+    async fn pre_middleware(_req: Request<String>) -> Request<String> {
+        Request::new(format!("{}\rFrom middleware", _req.body()))
+    }
+
+    async fn test_handler(_req: Request<String>) -> Response<String> {
+        Response::new(format!("{}\rFrom the handler", _req.body()))
+    }
+
+    #[async_test]
+    async fn test_pre_middleware() -> std::io::Result<()> {
+        let middleware = MiddlewareFactory::new();
+
+        let middleware = middleware.pre(pre_middleware);
+        let arc_middleware = Arc::new(middleware);
+
+        let updated_handler = arc_middleware.build(
+            test_handler,
+            &String::with_capacity(0),
+            &String::with_capacity(0),
+        );
+
+        let resp = updated_handler(Request::new("From pure request".to_owned())).await;
+
+        assert!(resp.body() == "From pure request\rFrom middleware\rFrom the handler");
+
+        Ok(())
+    }
+}

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -5,6 +5,7 @@ use futures::Future;
 use crate::{
     handler::{encapsulate_runner, BoxedHandler, Runner},
     request::Request,
+    response::Response,
 };
 
 pub trait PreMiddleware: Send + Sync + Clone {
@@ -24,16 +25,79 @@ where
     }
 }
 
-impl<FPre, FAfter, F> MiddlewareFactory<FPre, FAfter>
+pub trait AfterMiddleware: Send + Sync + Clone {
+    type FutCallResponse;
+    fn call(&self, req: Response<String>) -> Self::FutCallResponse;
+}
+
+impl<MidFn, Fut> AfterMiddleware for MidFn
+where
+    MidFn: Fn(Response<String>) -> Fut + Send + Sync + Clone,
+    Fut: Future<Output = Response<String>>,
+{
+    type FutCallResponse = Fut;
+    #[inline(always)]
+    fn call(&self, req: Response<String>) -> Self::FutCallResponse {
+        self(req)
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct MiddlewareFactory<FPre, FAfter> {
+    pre: FPre,
+    after: FAfter,
+}
+
+impl MiddlewareFactory<(), ()> {
+    #[inline(always)]
+    async fn unit_pre_middleware(request: Request<String>) -> Request<String> {
+        request
+    }
+
+    #[inline(always)]
+    async fn unit_after_middleware(response: Response<String>) -> Response<String> {
+        response
+    }
+
+    pub fn new() -> MiddlewareFactory<
+        impl PreMiddleware<FutCallResponse = impl Future<Output = Request<String>>>,
+        impl AfterMiddleware<FutCallResponse = impl Future<Output = Response<String>>>,
+    > {
+        MiddlewareFactory {
+            pre: Self::unit_pre_middleware,
+            after: Self::unit_after_middleware,
+        }
+    }
+
+    pub fn pre<F: Future<Output = Request<String>>, UPM: PreMiddleware<FutCallResponse = F>>(
+        self,
+        pre: UPM,
+    ) -> MiddlewareFactory<UPM, ()> {
+        MiddlewareFactory { pre, after: () }
+    }
+
+    pub fn after<
+        F: Future<Output = Response<String>>,
+        UAFM: AfterMiddleware<FutCallResponse = F>,
+    >(
+        self,
+        after: UAFM,
+    ) -> MiddlewareFactory<(), UAFM> {
+        MiddlewareFactory { pre: (), after }
+    }
+}
+
+impl<FPre, FAfter, F, FA> MiddlewareFactory<FPre, FAfter>
 where
     FPre: PreMiddleware<FutCallResponse = F> + 'static,
-    FAfter: 'static + Send + std::marker::Sync,
+    FAfter: AfterMiddleware<FutCallResponse = FA> + 'static,
     F: Future<Output = Request<String>> + Send,
+    FA: Future<Output = Response<String>> + Send,
 {
     #[inline(always)]
     pub fn pre<NewF: Future<Output = Request<String>>>(
         self,
-        _before: &'static (impl PreMiddleware<FutCallResponse = NewF> + Sync),
+        other_pre: &'static (impl PreMiddleware<FutCallResponse = NewF> + Sync),
     ) -> MiddlewareFactory<
         impl PreMiddleware<FutCallResponse = impl Future<Output = Request<String>>>,
         FAfter,
@@ -42,13 +106,35 @@ where
             let cloned_pre_middleware = self.pre.clone();
             async move {
                 let resp = cloned_pre_middleware.call(req).await;
-                _before.call(resp).await
+                other_pre.call(resp).await
             }
         };
 
         MiddlewareFactory {
             pre,
             after: self.after,
+        }
+    }
+
+    #[inline(always)]
+    pub fn after<NewF: Future<Output = Response<String>>>(
+        self,
+        other_after: &'static (impl AfterMiddleware<FutCallResponse = NewF> + Sync),
+    ) -> MiddlewareFactory<
+        FPre,
+        impl AfterMiddleware<FutCallResponse = impl Future<Output = Response<String>>>,
+    > {
+        let after = move |res| {
+            let cloned_after_middleware = self.after.clone();
+            async move {
+                let resp = cloned_after_middleware.call(res).await;
+                other_after.call(resp).await
+            }
+        };
+
+        MiddlewareFactory {
+            pre: self.pre,
+            after,
         }
     }
 
@@ -63,11 +149,13 @@ where
     {
         let handler = move |req| {
             let pre = self.pre.clone();
+            let after = self.after.clone();
             let runner = _runner.clone();
             async move {
                 let req_updated = pre.call(req).await;
-                let a = runner.call_runner(req_updated);
-                a.await
+                let a = runner.call_runner(req_updated).await;
+                let res_updated = after.call(a);
+                res_updated.await
             }
         };
 
@@ -76,25 +164,6 @@ where
             &String::with_capacity(0),
             &String::with_capacity(0),
         ))
-    }
-}
-
-#[derive(Debug, Default)]
-pub struct MiddlewareFactory<FPre, FAfter> {
-    pre: FPre,
-    after: FAfter,
-}
-
-impl MiddlewareFactory<(), ()> {
-    pub fn new() -> Self {
-        Self { pre: (), after: () }
-    }
-
-    pub fn pre<F: Future<Output = Request<String>>, UPM: PreMiddleware<FutCallResponse = F>>(
-        self,
-        pre: UPM,
-    ) -> MiddlewareFactory<UPM, ()> {
-        MiddlewareFactory { pre, after: () }
     }
 }
 
@@ -107,18 +176,23 @@ mod test {
     use crate::{middleware::MiddlewareFactory, request::Request, response::Response};
 
     async fn pre_middleware(_req: Request<String>) -> Request<String> {
-        Request::new(format!("{}\rFrom middleware", _req.body()))
+        Request::new(format!("{}\nFrom middleware", _req.body()))
     }
 
     async fn test_handler(_req: Request<String>) -> Response<String> {
-        Response::new(format!("{}\rFrom the handler", _req.body()))
+        Response::new(format!("{}\nFrom the handler", _req.body()))
+    }
+
+    async fn after_middleware(res: Response<String>) -> Response<String> {
+        Response::new(format!("{}\nFrom the after middleware", res.body()))
     }
 
     #[async_test]
-    async fn test_pre_middleware() -> std::io::Result<()> {
+    async fn test_middleware_creation() -> std::io::Result<()> {
         let middleware = MiddlewareFactory::new();
 
-        let middleware = middleware.pre(pre_middleware);
+        let middleware = middleware.pre(&pre_middleware);
+        let middleware = middleware.after(&after_middleware);
         let arc_middleware = Arc::new(middleware);
 
         let updated_handler = arc_middleware.build(
@@ -129,7 +203,9 @@ mod test {
 
         let resp = updated_handler(Request::new("From pure request".to_owned())).await;
 
-        assert!(resp.body() == "From pure request\rFrom middleware\rFrom the handler");
+        println!("{}", resp.body());
+
+        assert!(resp.body() == "From pure request\nFrom middleware\nFrom the handler\nFrom the after middleware");
 
         Ok(())
     }

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,4 +1,4 @@
-use crate::handler::Result;
+use crate::handler::InternalResult;
 
 pub type Method = http::Method;
 pub type Uri = http::Uri;
@@ -34,8 +34,8 @@ impl<T> Request<T> {
     // TODO: Valuate if this will keep this fn or move to an from_parts style
     pub fn and_then<BodyType>(
         self,
-        callback: impl FnOnce(T) -> Result<BodyType>,
-    ) -> Result<Request<BodyType>> {
+        callback: impl FnOnce(T) -> InternalResult<BodyType>,
+    ) -> InternalResult<Request<BodyType>> {
         let (parts, body) = self.request.into_parts();
         callback(body).map(|body| Request {
             request: HttpRequest::from_parts(parts, body),

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,6 +1,6 @@
 use http::{HeaderMap, HeaderValue};
 
-use crate::handler::Result;
+use crate::handler::InternalResult;
 
 pub type HttpResponse<T> = http::Response<T>;
 type HttpResponseBuilder = http::response::Builder;
@@ -54,8 +54,8 @@ impl<T> Response<T> {
     // TODO: Valuate if this will keep this fn or move to an from_parts style
     pub fn and_then<BodyType>(
         self,
-        callback: impl FnOnce(T) -> Result<BodyType>,
-    ) -> Result<Response<BodyType>> {
+        callback: impl FnOnce(T) -> InternalResult<BodyType>,
+    ) -> InternalResult<Response<BodyType>> {
         let (parts, body) = self.response.into_parts();
         callback(body).map(|body| Response {
             response: HttpResponse::from_parts(parts, body),


### PR DESCRIPTION
## About

Add `MiddlewareFactory` to help build new `Runner`s with `middleware`. This will be used on Routers to accept middleware attached to routers.

## Possible use cases

> Obs: "-`type`->" represent which is the data type sent between each stage
### 1st - Middleware that doesn't change the body of a request or response

- Connection -`Request`-> Logger -`Request`-> DoSomething -`Response`-> Logger -`Response`-> Connection
- Connection -`Request`-> Auth -`Request`-> DoSomething -`Response`-> Connection

### 2nd - Middleware that changes the body of a request or response

- Connection -`Request`-> Transformer -`Request'`-> DoSomething -`Response`-> OtherTransformer -`Response'`-> Connection

### 3rd - Middleware that changes the body of a request but not a response and vice-versa

- Connection -`Request`-> Transformer -`Request'`-> DoSomething -`Response`-> Logger -`Response'`-> Connection

## To-do

- [x] Implement the base for both `PreMiddleware` and `AfterMiddleware` traits
- [x] Analyze if it should short circuit when finding an error
- [x] Validate types of `middleware` signatures ( Make it more generic like the `Runner` case)
- [x] Implement more tests