### PR TITLE
Feat/Router

### DIFF
--- a/examples/router_example/main.rs
+++ b/examples/router_example/main.rs
@@ -1,0 +1,61 @@
+extern crate yahf;
+
+use std::time;
+use std::time::UNIX_EPOCH;
+
+use serde::Deserialize;
+use serde::Serialize;
+use yahf::handler::Json;
+use yahf::handler::Result;
+use yahf::request::Request;
+
+use yahf::router::Router;
+use yahf::server::Server;
+
+#[derive(Debug, Deserialize, Serialize)]
+struct ComputationBody {
+    value: u32,
+}
+
+async fn log_middleware(req: Result<Request<String>>) -> Result<Request<String>> {
+    match req.into_inner() {
+        Ok(req) => {
+            println!(
+                "{} - {} - {}",
+                time::SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .expect("Negative time")
+                    .as_millis(),
+                req.method().as_str(),
+                req.uri().path()
+            );
+
+            Ok(req).into()
+        }
+        Err(err) => Err(err).into(),
+    }
+}
+
+async fn first_computation(req: ComputationBody) -> ComputationBody {
+    ComputationBody {
+        value: req.value + 1,
+    }
+}
+
+async fn second_computation(req: ComputationBody) -> ComputationBody {
+    ComputationBody {
+        value: req.value * 2,
+    }
+}
+
+fn main() {
+    let mut router = Router::new().pre(log_middleware);
+    router.get("/first", first_computation, &Json::new(), &Json::new());
+
+    let mut server = Server::new();
+    server.get("/second", second_computation, &Json::new(), &Json::new());
+
+    let server = server.router(router);
+
+    server.listen("localhost:3000").unwrap();
+}

--- a/src/handle_selector.rs
+++ b/src/handle_selector.rs
@@ -37,7 +37,7 @@ impl<'a> HandlerSelect<'a> {
         }
 
         match (node.childrens, node.wildcard_node) {
-            (None, None) => unreachable!("Something went wrong, can't exist a Node that don't have either a Handler or children nodes"),
+            (None, None) => {}
             (None, Some(wildcard_node)) => {
                 path.push_str("/{wildcard_node}");
                 self.rec_extend(*wildcard_node, path);

--- a/src/handle_selector.rs
+++ b/src/handle_selector.rs
@@ -25,6 +25,39 @@ impl<'a> HandlerSelect<'a> {
         }
     }
 
+    pub fn extend(&mut self, another_handler: HandlerSelect<'a>) {
+        let root = another_handler.root;
+
+        self.rec_extend(root, "".to_owned());
+    }
+
+    fn rec_extend(&mut self, node: Node<'a>, mut path: String) {
+        if node.value.is_some() {
+            return self.insert(Box::leak(path.into_boxed_str()), node.value.unwrap());
+        }
+
+        match (node.childrens, node.wildcard_node) {
+            (None, None) => unreachable!("Something went wrong, can't exist a Node that don't have either a Handler or children nodes"),
+            (None, Some(wildcard_node)) => {
+                path.push_str("/{wildcard_node}");
+                self.rec_extend(*wildcard_node, path);
+            }
+            (Some(childrens), None) => {
+                childrens.into_iter().for_each(|(next_path_segment, node)| {
+                    self.rec_extend(node, format!("{}/{}", path, next_path_segment));
+                });
+            }
+            (Some(childrens), Some(wildcard_node)) => {
+                childrens.into_iter().for_each(|(next_path_segment, node)| {
+                    self.rec_extend(node, format!("{}/{}", path, next_path_segment));
+                });
+
+                path.push_str("{wildcard_node}");
+                self.rec_extend(*wildcard_node, path);
+            }
+        };
+    }
+
     pub fn insert(&mut self, path: &'a str, handler: BoxedHandler) {
         let mut node = &mut self.root;
         for splitted_path in path.split('/').filter(|x| !x.is_empty()) {
@@ -36,10 +69,12 @@ impl<'a> HandlerSelect<'a> {
             node = node.add_normal_node(splitted_path);
         }
 
+        if node.value.is_some() {
+            panic!("{} already defined", path);
+        }
         node.value = Some(handler);
     }
 
-    #[allow(dead_code)]
     pub fn get(&self, path: &str) -> Option<RefHandler<'_>> {
         let mut root = &self.root;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,4 +4,5 @@ pub mod handler;
 pub mod middleware;
 pub mod request;
 pub mod response;
+pub mod router;
 pub mod server;

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -99,10 +99,6 @@ where
     CFA: Into<InternalResult<Response<String>>> + Send,
     FA: Future<Output = CFA> + Send,
 {
-    pub(crate) fn into_parts(self) -> (FPre, FAfter) {
-        (self.pre, self.after)
-    }
-
     #[inline(always)]
     pub fn pre<NewF: Future<Output = NewCF>, NewCF: Into<InternalResult<Request<String>>>>(
         self,

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -92,8 +92,8 @@ impl MiddlewareFactory<(), ()> {
 
 impl<FPre, FAfter, F, FA, CF, CFA> MiddlewareFactory<FPre, FAfter>
 where
-    FPre: PreMiddleware<FutCallResponse = F> + 'static,
-    FAfter: AfterMiddleware<FutCallResponse = FA> + 'static,
+    FPre: PreMiddleware<FutCallResponse = F>,
+    FAfter: AfterMiddleware<FutCallResponse = FA>,
     F: Future<Output = CF> + Send,
     CF: Into<InternalResult<Request<String>>> + Send,
     CFA: Into<InternalResult<Response<String>>> + Send,

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -58,7 +58,7 @@ where
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct MiddlewareFactory<FPre, FAfter> {
     pre: FPre,
     after: FAfter,
@@ -99,7 +99,7 @@ where
     CFA: Into<InternalResult<Response<String>>> + Send,
     FA: Future<Output = CFA> + Send,
 {
-    pub fn into_parts(self) -> (FPre, FAfter) {
+    pub(crate) fn into_parts(self) -> (FPre, FAfter) {
         (self.pre, self.after)
     }
 

--- a/src/router.rs
+++ b/src/router.rs
@@ -2,9 +2,9 @@ use futures::Future;
 
 use crate::{
     handle_selector::HandlerSelect,
-    handler::InternalResult,
+    handler::{encapsulate_runner, InternalResult, RefHandler, Runner},
     middleware::{AfterMiddleware, MiddlewareFactory, PreMiddleware},
-    request::Request,
+    request::{Method, Request},
     response::Response,
 };
 
@@ -43,6 +43,26 @@ impl Router<(), ()> {
             head: HandlerSelect::new(),
         }
     }
+}
+
+macro_rules! method_insert {
+    ($fn: ident, $method: expr) => {
+        pub fn $fn<FnIn, FnOut, Deserializer, Serializer, R>(
+            &mut self,
+            path: &'static str,
+            handler: R,
+            deserializer: &Deserializer,
+            serializer: &Serializer,
+        ) where
+            R: 'static + Runner<(FnIn, Deserializer), (FnOut, Serializer)>,
+            FnIn: 'static,
+            FnOut: 'static,
+            Deserializer: 'static,
+            Serializer: 'static,
+        {
+            self.add_handler($method, path, handler, deserializer, serializer)
+        }
+    };
 }
 
 impl<MPre, MAfter, FutP, FutA, CFP, CFA> Router<MPre, MAfter>
@@ -99,4 +119,301 @@ where
             head: self.head,
         }
     }
+
+    pub fn add_handler<FnIn, FnOut, Deserializer, Serializer, R>(
+        &mut self,
+        method: Method,
+        path: &'static str,
+        handler: R,
+        deserializer: &Deserializer,
+        serializer: &Serializer,
+    ) where
+        R: 'static + Runner<(FnIn, Deserializer), (FnOut, Serializer)>,
+        FnIn: 'static,
+        FnOut: 'static,
+        Deserializer: 'static,
+        Serializer: 'static,
+    {
+        match method {
+            Method::GET => self.get.insert(
+                path,
+                Box::new(encapsulate_runner(handler, deserializer, serializer)),
+            ),
+            Method::PUT => self.put.insert(
+                path,
+                Box::new(encapsulate_runner(handler, deserializer, serializer)),
+            ),
+            Method::DELETE => self.delete.insert(
+                path,
+                Box::new(encapsulate_runner(handler, deserializer, serializer)),
+            ),
+            Method::POST => self.post.insert(
+                path,
+                Box::new(encapsulate_runner(handler, deserializer, serializer)),
+            ),
+            Method::TRACE => self.trace.insert(
+                path,
+                Box::new(encapsulate_runner(handler, deserializer, serializer)),
+            ),
+            Method::OPTIONS => self.options.insert(
+                path,
+                Box::new(encapsulate_runner(handler, deserializer, serializer)),
+            ),
+            Method::CONNECT => self.connect.insert(
+                path,
+                Box::new(encapsulate_runner(handler, deserializer, serializer)),
+            ),
+            Method::PATCH => self.patch.insert(
+                path,
+                Box::new(encapsulate_runner(handler, deserializer, serializer)),
+            ),
+            Method::HEAD => self.head.insert(
+                path,
+                Box::new(encapsulate_runner(handler, deserializer, serializer)),
+            ),
+            _ => unreachable!("Only acceptable HTTP methods are GET, POST, PUT, DELETE, TRACE, OPTIONS, CONNECT, PATCH, HEAD"),
+        }
+    }
+
+    method_insert!(get, Method::GET);
+    method_insert!(put, Method::PUT);
+    method_insert!(delete, Method::DELETE);
+    method_insert!(post, Method::POST);
+    method_insert!(trace, Method::TRACE);
+    method_insert!(options, Method::OPTIONS);
+    method_insert!(connect, Method::CONNECT);
+    method_insert!(patch, Method::PATCH);
+    method_insert!(head, Method::HEAD);
+
+    pub(crate) fn find_handler(&self, method: &Method, path: &str) -> Option<RefHandler<'_>> {
+        match *method {
+            Method::GET => self.get.get(path),
+            Method::PUT => self.put.get(path),
+            Method::POST => self.post.get(path),
+            Method::DELETE => self.delete.get(path),
+            Method::TRACE => self.trace.get(path),
+            Method::OPTIONS => self.options.get(path),
+            Method::CONNECT => self.connect.get(path),
+            Method::PATCH => self.patch.get(path),
+            Method::HEAD => self.head.get(path),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    mod runners {
+        use crate::handler::Result;
+        use crate::request::Request;
+        use crate::response::Response;
+
+        pub async fn runner_void_string() -> String {
+            "1".into()
+        }
+
+        pub async fn runner_void_resp_string() -> Response<String> {
+            Response::new("2".into())
+        }
+
+        pub async fn runner_void_result_string() -> Result<String> {
+            Ok("3".into()).into()
+        }
+
+        pub async fn runner_void_result_response_string() -> Result<Response<String>> {
+            Ok(Response::new("4".into())).into()
+        }
+
+        pub async fn runner_string_string(_req: String) -> String {
+            "5".into()
+        }
+
+        pub async fn runner_string_result_string(_req: String) -> Result<String> {
+            Ok("6".into()).into()
+        }
+
+        pub async fn runner_string_res_string(_req: String) -> Response<String> {
+            Response::new("7".into())
+        }
+
+        pub async fn runner_string_result_res_string(_req: String) -> Result<Response<String>> {
+            Ok(Response::new("8".into())).into()
+        }
+
+        pub async fn runner_req_string_resp_string(_req: Request<String>) -> Response<String> {
+            Response::new("9".into())
+        }
+
+        pub async fn runner_req_string_string(_req: Request<String>) -> String {
+            "10".into()
+        }
+    }
+
+    mod utils {
+        use crate::{
+            handler::RefHandler,
+            request::{Method, Request},
+            response::Response,
+        };
+
+        pub fn create_request(body: String, method: Method) -> Request<String> {
+            Request::builder()
+                .method(method)
+                .header("Content-Length", body.len())
+                .body(body)
+        }
+
+        pub fn test_runner_response(body: String, expected_body: String) {
+            assert!(body == expected_body);
+        }
+
+        pub async fn run_runner(
+            runner: RefHandler<'_>,
+            request: Request<String>,
+        ) -> Response<String> {
+            runner(request).await
+        }
+    }
+
+    macro_rules! test_router_insert_and_find {
+        ($test_name: ident, $router_method: expr, $method: expr, $runner: expr,$des: expr, $body: literal, $expected_body: literal) => {
+            #[async_test]
+            async fn $test_name() -> std::io::Result<()> {
+                let request = super::utils::create_request($body.to_owned(), $method);
+                let router = &mut Router::new();
+                $router_method(router, "/path/to", $runner, $des, &String::with_capacity(0));
+                let handler = Router::find_handler(router, request.method(), "/path/to");
+
+                assert!(handler.is_some());
+
+                let response = super::utils::run_runner(handler.unwrap(), request).await;
+
+                super::utils::test_runner_response(
+                    response.body().to_owned(),
+                    $expected_body.to_owned(),
+                );
+
+                Ok(())
+            }
+        };
+    }
+
+    macro_rules! test_router_insert_and_find_for_method {
+        ($mod_name: ident, $router_method: expr, $method: expr) => {
+            mod $mod_name {
+                use crate::request::Method;
+                use crate::router::Router;
+                use async_std_test::async_test;
+
+                test_router_insert_and_find!(
+                    test_insert_and_find_runner_void_string,
+                    $router_method,
+                    $method,
+                    super::runners::runner_void_string,
+                    &(),
+                    "1",
+                    "1"
+                );
+                test_router_insert_and_find!(
+                    test_insert_and_find_runner_void_resp_string,
+                    $router_method,
+                    $method,
+                    super::runners::runner_void_resp_string,
+                    &(),
+                    "2",
+                    "2"
+                );
+
+                test_router_insert_and_find!(
+                    test_insert_and_find_runner_void_result_string,
+                    $router_method,
+                    $method,
+                    super::runners::runner_void_result_string,
+                    &(),
+                    "3",
+                    "3"
+                );
+
+                test_router_insert_and_find!(
+                    test_insert_and_find_runner_void_result_response_string,
+                    $router_method,
+                    $method,
+                    super::runners::runner_void_result_response_string,
+                    &(),
+                    "4",
+                    "4"
+                );
+
+                test_router_insert_and_find!(
+                    test_insert_and_find_runner_string_string,
+                    $router_method,
+                    $method,
+                    super::runners::runner_string_string,
+                    &String::with_capacity(0),
+                    "5",
+                    "5"
+                );
+
+                test_router_insert_and_find!(
+                    test_insert_and_find_runner_string_result_string,
+                    $router_method,
+                    $method,
+                    super::runners::runner_string_result_string,
+                    &String::with_capacity(0),
+                    "6",
+                    "6"
+                );
+
+                test_router_insert_and_find!(
+                    test_insert_and_find_runner_string_res_string,
+                    $router_method,
+                    $method,
+                    super::runners::runner_string_res_string,
+                    &String::with_capacity(0),
+                    "7",
+                    "7"
+                );
+
+                test_router_insert_and_find!(
+                    test_insert_and_find_runner_string_result_res_string,
+                    $router_method,
+                    $method,
+                    super::runners::runner_string_result_res_string,
+                    &String::with_capacity(0),
+                    "8",
+                    "8"
+                );
+
+                test_router_insert_and_find!(
+                    test_insert_and_find_runner_req_string_resp_string,
+                    $router_method,
+                    $method,
+                    super::runners::runner_req_string_resp_string,
+                    &String::with_capacity(0),
+                    "9",
+                    "9"
+                );
+
+                test_router_insert_and_find!(
+                    test_insert_and_find_runner_req_string_string,
+                    $router_method,
+                    $method,
+                    super::runners::runner_req_string_string,
+                    &String::with_capacity(0),
+                    "10",
+                    "10"
+                );
+            }
+        };
+    }
+
+    test_router_insert_and_find_for_method!(get, Router::get, Method::GET);
+    test_router_insert_and_find_for_method!(put, Router::put, Method::PUT);
+    test_router_insert_and_find_for_method!(delete, Router::delete, Method::DELETE);
+    test_router_insert_and_find_for_method!(post, Router::post, Method::POST);
+    test_router_insert_and_find_for_method!(trace, Router::trace, Method::TRACE);
+    test_router_insert_and_find_for_method!(options, Router::options, Method::OPTIONS);
+    test_router_insert_and_find_for_method!(connect, Router::connect, Method::CONNECT);
+    test_router_insert_and_find_for_method!(patch, Router::patch, Method::PATCH);
+    test_router_insert_and_find_for_method!(head, Router::head, Method::HEAD);
 }

--- a/src/router.rs
+++ b/src/router.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use futures::Future;
 
 use crate::{
@@ -9,7 +11,7 @@ use crate::{
 };
 
 pub struct Router<MPre, MAfter> {
-    middleware_factory: MiddlewareFactory<MPre, MAfter>,
+    middleware_factory: Arc<MiddlewareFactory<MPre, MAfter>>,
     get: HandlerSelect<'static>,
     put: HandlerSelect<'static>,
     delete: HandlerSelect<'static>,
@@ -31,7 +33,7 @@ impl Router<(), ()> {
         >,
     > {
         Router {
-            middleware_factory: MiddlewareFactory::new(),
+            middleware_factory: Arc::new(MiddlewareFactory::new()),
             get: HandlerSelect::new(),
             put: HandlerSelect::new(),
             delete: HandlerSelect::new(),
@@ -60,19 +62,30 @@ macro_rules! method_insert {
             Deserializer: 'static,
             Serializer: 'static,
         {
-            self.add_handler($method, path, handler, deserializer, serializer)
+            let built_with_middleware =
+                self.middleware_factory
+                    .clone()
+                    .build(handler, deserializer, serializer);
+
+            self.add_handler(
+                $method,
+                path,
+                built_with_middleware,
+                &String::with_capacity(0),
+                &String::with_capacity(0),
+            )
         }
     };
 }
 
 impl<MPre, MAfter, FutP, FutA, CFP, CFA> Router<MPre, MAfter>
 where
-    MPre: PreMiddleware<FutCallResponse = FutP>,
-    FutP: Future<Output = CFP> + std::marker::Send,
-    CFP: Into<InternalResult<Request<String>>> + std::marker::Send,
-    MAfter: AfterMiddleware<FutCallResponse = FutA>,
-    FutA: Future<Output = CFA> + std::marker::Send,
-    CFA: Into<InternalResult<Response<String>>> + std::marker::Send,
+    MPre: PreMiddleware<FutCallResponse = FutP> + 'static,
+    FutP: Future<Output = CFP> + std::marker::Send + 'static,
+    CFP: Into<InternalResult<Request<String>>> + std::marker::Send + 'static,
+    MAfter: AfterMiddleware<FutCallResponse = FutA> + 'static,
+    FutA: Future<Output = CFA> + std::marker::Send + 'static,
+    CFA: Into<InternalResult<Response<String>>> + std::marker::Send + 'static,
 {
     pub fn extend<OtherMPre, OtherMAfter, OtherFutA, OtherFutP, OtherCFP, OtherCFA>(
         mut self,
@@ -107,7 +120,55 @@ where
         self.head.extend(router.head);
 
         Router {
-            middleware_factory: combined_middleware,
+            middleware_factory: Arc::new(combined_middleware),
+            get: self.get,
+            put: self.put,
+            delete: self.delete,
+            post: self.post,
+            trace: self.trace,
+            options: self.options,
+            connect: self.connect,
+            patch: self.patch,
+            head: self.head,
+        }
+    }
+
+    pub fn pre<NewPM, NewFut, NewCFP>(
+        self,
+        middleware: NewPM,
+    ) -> Router<impl PreMiddleware<FutCallResponse = impl Future<Output = NewCFP>>, MAfter>
+    where
+        NewPM: PreMiddleware<FutCallResponse = NewFut>,
+        NewFut: Future<Output = NewCFP>,
+        NewCFP: Into<InternalResult<Request<String>>>,
+    {
+        let new_factory = self.middleware_factory.pre(middleware);
+        Router {
+            middleware_factory: Arc::new(new_factory),
+            get: self.get,
+            put: self.put,
+            delete: self.delete,
+            post: self.post,
+            trace: self.trace,
+            options: self.options,
+            connect: self.connect,
+            patch: self.patch,
+            head: self.head,
+        }
+    }
+
+    pub fn after<NewAM, NewFut, NewCFA>(
+        self,
+        middleware: NewAM,
+    ) -> Router<MPre, impl AfterMiddleware<FutCallResponse = impl Future<Output = NewCFA>>>
+    where
+        NewAM: AfterMiddleware<FutCallResponse = NewFut>,
+        NewFut: Future<Output = NewCFA>,
+        NewCFA: Into<InternalResult<Response<String>>>,
+    {
+        let new_factory = self.middleware_factory.after(middleware);
+        Router {
+            middleware_factory: Arc::new(new_factory),
             get: self.get,
             put: self.put,
             delete: self.delete,
@@ -185,6 +246,7 @@ where
     method_insert!(patch, Method::PATCH);
     method_insert!(head, Method::HEAD);
 
+    #[allow(dead_code)]
     pub(crate) fn find_handler(&self, method: &Method, path: &str) -> Option<RefHandler<'_>> {
         match *method {
             Method::GET => self.get.get(path),
@@ -247,6 +309,10 @@ mod test {
         pub async fn runner_req_string_string(_req: Request<String>) -> String {
             "10".into()
         }
+
+        pub async fn runner_encapsulate_string(req: String) -> String {
+            format!("[{}]", req)
+        }
     }
 
     mod utils {
@@ -275,12 +341,39 @@ mod test {
         }
     }
 
+    macro_rules! build_router {
+        ($id: ident, [$pre: expr]) => {
+            let $id = Router::pre($id, $pre);
+        };
+        ($id: ident, ($after: expr)) => {
+            let $id = Router::after($id, $after);
+        };
+        ($id: ident, [$($pre: expr),+]) => {
+            $(build_router!($id, [$pre]);)+
+        };
+        ($id: ident, ($($after: expr),+)) => {
+            $(build_router!($id, ($after));)+
+        };
+        ($id: ident, [$($pre: expr),*], ($($after:expr),*)) => {
+            $(build_router!($id,[$pre]);)*
+            $(build_router!($id,($after));)*
+        }
+    }
+
     macro_rules! test_router_insert_and_find {
-        ($test_name: ident, $router_method: expr, $method: expr, $runner: expr,$des: expr, $body: literal, $expected_body: literal) => {
+        ($test_name: ident, $router_method: expr, $method: expr, $runner: expr,$des: expr, $body: literal, $expected_body: literal, [$($pre: expr),*], ($($after:expr),*)) => {
             #[async_test]
             async fn $test_name() -> std::io::Result<()> {
                 let request = super::utils::create_request($body.to_owned(), $method);
-                let router = &mut Router::new();
+                let router = Router::new();
+
+                build_router!(
+                    router,
+                    [$($pre),*],
+                    ($($after),*)
+                );
+                let mut router = router;
+                let router = &mut router;
                 $router_method(router, "/path/to", $runner, $des, &String::with_capacity(0));
                 let handler = Router::find_handler(router, request.method(), "/path/to");
 
@@ -295,6 +388,9 @@ mod test {
 
                 Ok(())
             }
+        };
+        ($test_name: ident, $router_method: expr, $method: expr, $runner: expr,$des: expr, $body: literal, $expected_body: literal) => {
+            test_router_insert_and_find!($test_name, $router_method, $method, $runner, $des, $body, $expected_body, [], ());
         };
     }
 
@@ -407,13 +503,243 @@ mod test {
         };
     }
 
-    test_router_insert_and_find_for_method!(get, Router::get, Method::GET);
-    test_router_insert_and_find_for_method!(put, Router::put, Method::PUT);
-    test_router_insert_and_find_for_method!(delete, Router::delete, Method::DELETE);
-    test_router_insert_and_find_for_method!(post, Router::post, Method::POST);
-    test_router_insert_and_find_for_method!(trace, Router::trace, Method::TRACE);
-    test_router_insert_and_find_for_method!(options, Router::options, Method::OPTIONS);
-    test_router_insert_and_find_for_method!(connect, Router::connect, Method::CONNECT);
-    test_router_insert_and_find_for_method!(patch, Router::patch, Method::PATCH);
-    test_router_insert_and_find_for_method!(head, Router::head, Method::HEAD);
+    test_router_insert_and_find_for_method!(test_insert_and_find_for_get, Router::get, Method::GET);
+    test_router_insert_and_find_for_method!(test_insert_and_find_for_put, Router::put, Method::PUT);
+    test_router_insert_and_find_for_method!(
+        test_insert_and_find_for_delete,
+        Router::delete,
+        Method::DELETE
+    );
+    test_router_insert_and_find_for_method!(
+        test_insert_and_find_for_post,
+        Router::post,
+        Method::POST
+    );
+    test_router_insert_and_find_for_method!(
+        test_insert_and_find_for_trace,
+        Router::trace,
+        Method::TRACE
+    );
+    test_router_insert_and_find_for_method!(
+        test_insert_and_find_for_options,
+        Router::options,
+        Method::OPTIONS
+    );
+    test_router_insert_and_find_for_method!(
+        test_insert_and_find_for_connect,
+        Router::connect,
+        Method::CONNECT
+    );
+    test_router_insert_and_find_for_method!(
+        test_insert_and_find_for_patch,
+        Router::patch,
+        Method::PATCH
+    );
+    test_router_insert_and_find_for_method!(
+        test_insert_and_find_for_head,
+        Router::head,
+        Method::HEAD
+    );
+
+    mod middlewares {
+        use crate::error::Error;
+        use crate::handler::Result;
+        use crate::request::Request;
+        use crate::response::Response;
+
+        pub async fn pre_transform(req: Result<Request<String>>) -> Result<Request<String>> {
+            req.into_inner().map(|_| Request::new("PM1".into())).into()
+        }
+
+        pub async fn pre_generate_error(_req: Result<Request<String>>) -> Result<Request<String>> {
+            Err(Error::new("PM2".into(), 500)).into()
+        }
+
+        pub async fn pre_handle_error(req: Result<Request<String>>) -> Result<Request<String>> {
+            Ok(req.into_inner().unwrap_or(Request::new("PM3".into()))).into()
+        }
+
+        pub async fn after_transform(res: Result<Response<String>>) -> Result<Response<String>> {
+            res.into_inner().map(|_| Response::new("AM1".into())).into()
+        }
+
+        pub async fn after_generate_error(
+            _res: Result<Response<String>>,
+        ) -> Result<Response<String>> {
+            Err(Error::new("AM2".into(), 500)).into()
+        }
+
+        pub async fn after_handle_error(res: Result<Response<String>>) -> Result<Response<String>> {
+            Ok(res.into_inner().unwrap_or(Response::new("AM3".into()))).into()
+        }
+    }
+
+    macro_rules! test_router_using_middlewares {
+        ($mod_name:ident, $router_method: expr, $method: expr) => {
+            mod $mod_name {
+                use crate::{
+                    request::Method,
+                    router::{
+                        test::{middlewares, runners},
+                        Router,
+                    },
+                };
+
+                use async_std_test::async_test;
+
+                test_router_insert_and_find!(
+                    test_pre_transform,
+                    $router_method,
+                    $method,
+                    runners::runner_encapsulate_string,
+                    &String::with_capacity(0),
+                    "Body",
+                    "[PM1]",
+                    [middlewares::pre_transform],
+                    ()
+                );
+
+                test_router_insert_and_find!(
+                    test_pre_generate_error,
+                    $router_method,
+                    $method,
+                    runners::runner_encapsulate_string,
+                    &String::with_capacity(0),
+                    "Body",
+                    "PM2",
+                    [middlewares::pre_transform, middlewares::pre_generate_error],
+                    ()
+                );
+
+                test_router_insert_and_find!(
+                    test_handle_pre_middleware_error,
+                    $router_method,
+                    $method,
+                    runners::runner_encapsulate_string,
+                    &String::with_capacity(0),
+                    "Body",
+                    "[PM3]",
+                    [
+                        middlewares::pre_transform,
+                        middlewares::pre_generate_error,
+                        middlewares::pre_handle_error
+                    ],
+                    ()
+                );
+
+                test_router_insert_and_find!(
+                    test_after_transform,
+                    $router_method,
+                    $method,
+                    runners::runner_encapsulate_string,
+                    &String::with_capacity(0),
+                    "Body",
+                    "AM1",
+                    [
+                        middlewares::pre_transform,
+                        middlewares::pre_generate_error,
+                        middlewares::pre_handle_error
+                    ],
+                    (middlewares::after_transform)
+                );
+
+                test_router_insert_and_find!(
+                    test_after_generate_error,
+                    $router_method,
+                    $method,
+                    runners::runner_encapsulate_string,
+                    &String::with_capacity(0),
+                    "Body",
+                    "AM2",
+                    [
+                        middlewares::pre_transform,
+                        middlewares::pre_generate_error,
+                        middlewares::pre_handle_error
+                    ],
+                    (
+                        middlewares::after_transform,
+                        middlewares::after_generate_error
+                    )
+                );
+
+                test_router_insert_and_find!(
+                    test_handle_after_error,
+                    $router_method,
+                    $method,
+                    runners::runner_encapsulate_string,
+                    &String::with_capacity(0),
+                    "Body",
+                    "AM3",
+                    [
+                        middlewares::pre_transform,
+                        middlewares::pre_generate_error,
+                        middlewares::pre_handle_error
+                    ],
+                    (
+                        middlewares::after_transform,
+                        middlewares::after_generate_error,
+                        middlewares::after_handle_error
+                    )
+                );
+
+                test_router_insert_and_find!(
+                    test_handle_pre_error_with_after_middleware,
+                    $router_method,
+                    $method,
+                    runners::runner_encapsulate_string,
+                    &String::with_capacity(0),
+                    "Body",
+                    "AM3",
+                    [middlewares::pre_generate_error],
+                    (middlewares::after_handle_error)
+                );
+            }
+        };
+    }
+
+    test_router_using_middlewares!(
+        test_router_using_middlewares_for_get,
+        Router::get,
+        Method::GET
+    );
+    test_router_using_middlewares!(
+        test_router_using_middlewares_for_put,
+        Router::put,
+        Method::PUT
+    );
+    test_router_using_middlewares!(
+        test_router_using_middlewares_for_delete,
+        Router::delete,
+        Method::DELETE
+    );
+    test_router_using_middlewares!(
+        test_router_using_middlewares_for_post,
+        Router::post,
+        Method::POST
+    );
+    test_router_using_middlewares!(
+        test_router_using_middlewares_for_trace,
+        Router::trace,
+        Method::TRACE
+    );
+    test_router_using_middlewares!(
+        test_router_using_middlewares_for_options,
+        Router::options,
+        Method::OPTIONS
+    );
+    test_router_using_middlewares!(
+        test_router_using_middlewares_for_connect,
+        Router::connect,
+        Method::CONNECT
+    );
+    test_router_using_middlewares!(
+        test_router_using_middlewares_for_patch,
+        Router::patch,
+        Method::PATCH
+    );
+    test_router_using_middlewares!(
+        test_router_using_middlewares_for_head,
+        Router::head,
+        Method::HEAD
+    );
 }

--- a/src/router.rs
+++ b/src/router.rs
@@ -1,0 +1,102 @@
+use futures::Future;
+
+use crate::{
+    handle_selector::HandlerSelect,
+    handler::InternalResult,
+    middleware::{AfterMiddleware, MiddlewareFactory, PreMiddleware},
+    request::Request,
+    response::Response,
+};
+
+pub struct Router<MPre, MAfter> {
+    middleware_factory: MiddlewareFactory<MPre, MAfter>,
+    get: HandlerSelect<'static>,
+    put: HandlerSelect<'static>,
+    delete: HandlerSelect<'static>,
+    post: HandlerSelect<'static>,
+    trace: HandlerSelect<'static>,
+    options: HandlerSelect<'static>,
+    connect: HandlerSelect<'static>,
+    patch: HandlerSelect<'static>,
+    head: HandlerSelect<'static>,
+}
+
+impl Router<(), ()> {
+    pub fn new() -> Router<
+        impl PreMiddleware<
+            FutCallResponse = impl Future<Output = impl Into<InternalResult<Request<String>>>>,
+        >,
+        impl AfterMiddleware<
+            FutCallResponse = impl Future<Output = impl Into<InternalResult<Response<String>>>>,
+        >,
+    > {
+        Router {
+            middleware_factory: MiddlewareFactory::new(),
+            get: HandlerSelect::new(),
+            put: HandlerSelect::new(),
+            delete: HandlerSelect::new(),
+            post: HandlerSelect::new(),
+            trace: HandlerSelect::new(),
+            options: HandlerSelect::new(),
+            connect: HandlerSelect::new(),
+            patch: HandlerSelect::new(),
+            head: HandlerSelect::new(),
+        }
+    }
+}
+
+impl<MPre, MAfter, FutP, FutA, CFP, CFA> Router<MPre, MAfter>
+where
+    MPre: PreMiddleware<FutCallResponse = FutP>,
+    FutP: Future<Output = CFP> + std::marker::Send,
+    CFP: Into<InternalResult<Request<String>>> + std::marker::Send,
+    MAfter: AfterMiddleware<FutCallResponse = FutA>,
+    FutA: Future<Output = CFA> + std::marker::Send,
+    CFA: Into<InternalResult<Response<String>>> + std::marker::Send,
+{
+    pub fn extend<OtherMPre, OtherMAfter, OtherFutA, OtherFutP, OtherCFP, OtherCFA>(
+        mut self,
+        router: Router<OtherMPre, OtherMAfter>,
+    ) -> Router<
+        impl PreMiddleware<
+            FutCallResponse = impl Future<Output = impl Into<InternalResult<Request<String>>>>,
+        >,
+        impl AfterMiddleware<
+            FutCallResponse = impl Future<Output = impl Into<InternalResult<Response<String>>>>,
+        >,
+    >
+    where
+        OtherMPre: PreMiddleware<FutCallResponse = OtherFutP> + 'static,
+        OtherMAfter: AfterMiddleware<FutCallResponse = OtherFutA> + 'static,
+        OtherFutP: Future<Output = OtherCFP> + Send,
+        OtherFutA: Future<Output = OtherCFA> + Send,
+        OtherCFP: Into<InternalResult<Request<String>>> + Send,
+        OtherCFA: Into<InternalResult<Response<String>>> + Send,
+    {
+        let (other_pre, other_after) = router.middleware_factory.into_parts();
+        let combined_middleware = self.middleware_factory.pre(other_pre).after(other_after);
+
+        self.get.extend(router.get);
+        self.put.extend(router.put);
+        self.delete.extend(router.delete);
+        self.post.extend(router.post);
+        self.trace.extend(router.trace);
+        self.options.extend(router.options);
+        self.connect.extend(router.connect);
+        self.patch.extend(router.patch);
+        self.head.extend(router.head);
+
+        Router {
+            middleware_factory: combined_middleware,
+            get: self.get,
+            put: self.put,
+            delete: self.delete,
+            post: self.post,
+            trace: self.trace,
+            options: self.options,
+            connect: self.connect,
+            patch: self.patch,
+            head: self.head,
+        }
+    }
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,9 +1,15 @@
-use std::{fmt::Display, sync::Arc};
+use std::{
+    fmt::Display,
+    ops::{Deref, DerefMut},
+    sync::Arc,
+};
 
 use crate::{
-    handle_selector,
-    handler::{encapsulate_runner, RefHandler, Runner},
+    handler::InternalResult,
+    middleware::{AfterMiddleware, PreMiddleware},
     request::{self, HttpHeaderName, HttpHeaderValue, Request, Uri},
+    response::Response,
+    router::Router,
 };
 use async_std::{
     io::{BufReader, WriteExt},
@@ -14,341 +20,94 @@ use async_std::{
     net::{TcpListener, ToSocketAddrs},
     stream::StreamExt,
 };
-use futures::{AsyncBufReadExt, AsyncRead, AsyncWrite};
-use handle_selector::HandlerSelect;
+use futures::{AsyncBufReadExt, AsyncRead, AsyncWrite, Future};
 
 use request::Method;
 
-#[derive(Default)]
-pub struct Server<'a> {
-    get: HandlerSelect<'a>,
-    put: HandlerSelect<'a>,
-    delete: HandlerSelect<'a>,
-    post: HandlerSelect<'a>,
-    trace: HandlerSelect<'a>,
-    options: HandlerSelect<'a>,
-    connect: HandlerSelect<'a>,
-    patch: HandlerSelect<'a>,
-    head: HandlerSelect<'a>,
+pub struct Server<PreM, AfterM> {
+    router: Router<PreM, AfterM>,
 }
 
-impl<'a: 'static> Server<'a> {
-    pub fn new() -> Self {
-        Self {
-            get: HandlerSelect::new(),
-            put: HandlerSelect::new(),
-            delete: HandlerSelect::new(),
-            post: HandlerSelect::new(),
-            trace: HandlerSelect::new(),
-            options: HandlerSelect::new(),
-            connect: HandlerSelect::new(),
-            patch: HandlerSelect::new(),
-            head: HandlerSelect::new(),
+impl<PreM, FutP, ResultP, AfterM, FutA, ResultA> Deref for Server<PreM, AfterM>
+where
+    PreM: PreMiddleware<FutCallResponse = FutP>,
+    FutP: Future<Output = ResultP>,
+    ResultP: Into<InternalResult<Request<String>>>,
+    AfterM: AfterMiddleware<FutCallResponse = FutA>,
+    FutA: Future<Output = ResultA>,
+    ResultA: Into<InternalResult<Response<String>>>,
+{
+    type Target = Router<PreM, AfterM>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.router
+    }
+}
+
+impl<PreM, FutP, ResultP, AfterM, FutA, ResultA> DerefMut for Server<PreM, AfterM>
+where
+    PreM: PreMiddleware<FutCallResponse = FutP>,
+    FutP: Future<Output = ResultP>,
+    ResultP: Into<InternalResult<Request<String>>>,
+    AfterM: AfterMiddleware<FutCallResponse = FutA>,
+    FutA: Future<Output = ResultA>,
+    ResultA: Into<InternalResult<Response<String>>>,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.router
+    }
+}
+
+impl Server<(), ()> {
+    pub fn new() -> Server<
+        impl PreMiddleware<
+            FutCallResponse = impl Future<Output = impl Into<InternalResult<Request<String>>>>,
+        >,
+        impl AfterMiddleware<
+            FutCallResponse = impl Future<Output = impl Into<InternalResult<Response<String>>>>,
+        >,
+    > {
+        Server {
+            router: Router::new(),
         }
     }
+}
 
-    pub fn add_handler<FnIn, FnOut, Deserializer, Serializer, R>(
-        &mut self,
-        method: Method,
-        path: &'static str,
-        handler: R,
-        deserializer: &Deserializer,
-        serializer: &Serializer,
-    ) where
-        R: 'static + Runner<(FnIn, Deserializer), (FnOut, Serializer)>,
-        FnIn: 'static,
-        FnOut: 'static,
-        Deserializer: 'static,
-        Serializer: 'static,
+impl<PreM, FutP, ResultP, AfterM, FutA, ResultA> Server<PreM, AfterM>
+where
+    PreM: PreMiddleware<FutCallResponse = FutP> + 'static,
+    FutP: Future<Output = ResultP> + std::marker::Send + 'static,
+    ResultP: Into<InternalResult<Request<String>>> + std::marker::Send + 'static,
+    AfterM: AfterMiddleware<FutCallResponse = FutA> + 'static,
+    FutA: Future<Output = ResultA> + std::marker::Send + 'static,
+    ResultA: Into<InternalResult<Response<String>>> + std::marker::Send + 'static,
+{
+    pub fn pre<NewPreM, NewFut, NewResultP>(
+        self,
+        middleware: NewPreM,
+    ) -> Server<impl PreMiddleware<FutCallResponse = impl Future<Output = NewResultP>>, AfterM>
+    where
+        NewPreM: PreMiddleware<FutCallResponse = NewFut>,
+        NewFut: Future<Output = NewResultP>,
+        NewResultP: Into<InternalResult<Request<String>>>,
     {
-        match method {
-            Method::GET => self.get.insert(
-                path,
-                Box::new(encapsulate_runner(handler, deserializer, serializer)),
-            ),
-            Method::PUT => self.put.insert(
-                path,
-                Box::new(encapsulate_runner(handler, deserializer, serializer)),
-            ),
-            Method::DELETE => self.delete.insert(
-                path,
-                Box::new(encapsulate_runner(handler, deserializer, serializer)),
-            ),
-            Method::POST => self.post.insert(
-                path,
-                Box::new(encapsulate_runner(handler, deserializer, serializer)),
-            ),
-            Method::TRACE => self.trace.insert(
-                path,
-                Box::new(encapsulate_runner(handler, deserializer, serializer)),
-            ),
-            Method::OPTIONS => self.options.insert(
-                path,
-                Box::new(encapsulate_runner(handler, deserializer, serializer)),
-            ),
-            Method::CONNECT => self.connect.insert(
-                path,
-                Box::new(encapsulate_runner(handler, deserializer, serializer)),
-            ),
-            Method::PATCH => self.patch.insert(
-                path,
-                Box::new(encapsulate_runner(handler, deserializer, serializer)),
-            ),
-            Method::HEAD => self.head.insert(
-                path,
-                Box::new(encapsulate_runner(handler, deserializer, serializer)),
-            ),
-            _ => (),
-        }
+        let new_router = self.router.pre(middleware);
+
+        Server { router: new_router }
     }
 
-    pub fn get<FnIn, FnOut, Deserializer, Serializer, R>(
-        &mut self,
-        path: &'static str,
-        handler: R,
-        deserializer: &Deserializer,
-        serializer: &Serializer,
-    ) where
-        R: 'static + Runner<(FnIn, Deserializer), (FnOut, Serializer)>,
-        FnIn: 'static,
-        FnOut: 'static,
-        Deserializer: 'static,
-        Serializer: 'static,
+    pub fn after<NewAfterM, NewFut, NewResultA>(
+        self,
+        middleware: NewAfterM,
+    ) -> Server<PreM, impl AfterMiddleware<FutCallResponse = impl Future<Output = NewResultA>>>
+    where
+        NewAfterM: AfterMiddleware<FutCallResponse = NewFut>,
+        NewFut: Future<Output = NewResultA>,
+        NewResultA: Into<InternalResult<Response<String>>>,
     {
-        self.add_handler(Method::GET, path, handler, deserializer, serializer)
-    }
+        let new_router = self.router.after(middleware);
 
-    pub fn post<FnIn, FnOut, Deserializer, Serializer, R>(
-        &mut self,
-        path: &'static str,
-        handler: R,
-        deserializer: &Deserializer,
-        serializer: &Serializer,
-    ) where
-        R: 'static + Runner<(FnIn, Deserializer), (FnOut, Serializer)>,
-        FnIn: 'static,
-        FnOut: 'static,
-        Deserializer: 'static,
-        Serializer: 'static,
-    {
-        self.add_handler(Method::POST, path, handler, deserializer, serializer)
-    }
-
-    pub fn put<FnIn, FnOut, Deserializer, Serializer, R>(
-        &mut self,
-        path: &'static str,
-        handler: R,
-        deserializer: &Deserializer,
-        serializer: &Serializer,
-    ) where
-        R: 'static + Runner<(FnIn, Deserializer), (FnOut, Serializer)>,
-        FnIn: 'static,
-        FnOut: 'static,
-        Deserializer: 'static,
-        Serializer: 'static,
-    {
-        self.add_handler(Method::PUT, path, handler, deserializer, serializer)
-    }
-
-    pub fn delete<FnIn, FnOut, Deserializer, Serializer, R>(
-        &mut self,
-        path: &'static str,
-        handler: R,
-        deserializer: &Deserializer,
-        serializer: &Serializer,
-    ) where
-        R: 'static + Runner<(FnIn, Deserializer), (FnOut, Serializer)>,
-        FnIn: 'static,
-        FnOut: 'static,
-        Deserializer: 'static,
-        Serializer: 'static,
-    {
-        self.add_handler(Method::DELETE, path, handler, deserializer, serializer)
-    }
-
-    pub fn trace<FnIn, FnOut, Deserializer, Serializer, R>(
-        &mut self,
-        path: &'static str,
-        handler: R,
-        deserializer: &Deserializer,
-        serializer: &Serializer,
-    ) where
-        R: 'static + Runner<(FnIn, Deserializer), (FnOut, Serializer)>,
-        FnIn: 'static,
-        FnOut: 'static,
-        Deserializer: 'static,
-        Serializer: 'static,
-    {
-        self.add_handler(Method::TRACE, path, handler, deserializer, serializer)
-    }
-
-    pub fn options<FnIn, FnOut, Deserializer, Serializer, R>(
-        &mut self,
-        path: &'static str,
-        handler: R,
-        deserializer: &Deserializer,
-        serializer: &Serializer,
-    ) where
-        R: 'static + Runner<(FnIn, Deserializer), (FnOut, Serializer)>,
-        FnIn: 'static,
-        FnOut: 'static,
-        Deserializer: 'static,
-        Serializer: 'static,
-    {
-        self.add_handler(Method::OPTIONS, path, handler, deserializer, serializer)
-    }
-
-    pub fn connect<FnIn, FnOut, Deserializer, Serializer, R>(
-        &mut self,
-        path: &'static str,
-        handler: R,
-        deserializer: &Deserializer,
-        serializer: &Serializer,
-    ) where
-        R: 'static + Runner<(FnIn, Deserializer), (FnOut, Serializer)>,
-        FnIn: 'static,
-        FnOut: 'static,
-        Deserializer: 'static,
-        Serializer: 'static,
-    {
-        self.add_handler(Method::CONNECT, path, handler, deserializer, serializer)
-    }
-
-    pub fn patch<FnIn, FnOut, Deserializer, Serializer, R>(
-        &mut self,
-        path: &'static str,
-        handler: R,
-        deserializer: &Deserializer,
-        serializer: &Serializer,
-    ) where
-        R: 'static + Runner<(FnIn, Deserializer), (FnOut, Serializer)>,
-        FnIn: 'static,
-        FnOut: 'static,
-        Deserializer: 'static,
-        Serializer: 'static,
-    {
-        self.add_handler(Method::PATCH, path, handler, deserializer, serializer)
-    }
-
-    pub fn head<FnIn, FnOut, Deserializer, Serializer, R>(
-        &mut self,
-        path: &'static str,
-        handler: R,
-        deserializer: &Deserializer,
-        serializer: &Serializer,
-    ) where
-        R: 'static + Runner<(FnIn, Deserializer), (FnOut, Serializer)>,
-        FnIn: 'static,
-        FnOut: 'static,
-        Deserializer: 'static,
-        Serializer: 'static,
-    {
-        self.add_handler(Method::HEAD, path, handler, deserializer, serializer)
-    }
-
-    pub fn all<FnIn, FnOut, Deserializer, Serializer, R>(
-        &mut self,
-        path: &'static str,
-        handler: R,
-        deserializer: &Deserializer,
-        serializer: &Serializer,
-    ) where
-        R: 'static + Runner<(FnIn, Deserializer), (FnOut, Serializer)>,
-        FnIn: 'static,
-        FnOut: 'static,
-        Deserializer: 'static,
-        Serializer: 'static,
-    {
-        if let (None, None, None, None) = (
-            self.get.get(path),
-            self.post.get(path),
-            self.put.get(path),
-            self.delete.get(path),
-        ) {
-            self.get.insert(
-                path,
-                Box::new(encapsulate_runner(
-                    handler.clone(),
-                    deserializer,
-                    serializer,
-                )),
-            );
-            self.post.insert(
-                path,
-                Box::new(encapsulate_runner(
-                    handler.clone(),
-                    deserializer,
-                    serializer,
-                )),
-            );
-            self.put.insert(
-                path,
-                Box::new(encapsulate_runner(
-                    handler.clone(),
-                    deserializer,
-                    serializer,
-                )),
-            );
-            self.delete.insert(
-                path,
-                Box::new(encapsulate_runner(
-                    handler.clone(),
-                    deserializer,
-                    serializer,
-                )),
-            );
-            self.trace.insert(
-                path,
-                Box::new(encapsulate_runner(
-                    handler.clone(),
-                    deserializer,
-                    serializer,
-                )),
-            );
-            self.options.insert(
-                path,
-                Box::new(encapsulate_runner(
-                    handler.clone(),
-                    deserializer,
-                    serializer,
-                )),
-            );
-            self.patch.insert(
-                path,
-                Box::new(encapsulate_runner(
-                    handler.clone(),
-                    deserializer,
-                    serializer,
-                )),
-            );
-            self.head.insert(
-                path,
-                Box::new(encapsulate_runner(
-                    handler.clone(),
-                    deserializer,
-                    serializer,
-                )),
-            );
-            self.connect.insert(
-                path,
-                Box::new(encapsulate_runner(handler, deserializer, serializer)),
-            );
-        }
-    }
-
-    fn find_handler(&self, method: &Method, path: &str) -> Option<RefHandler<'_>> {
-        match *method {
-            Method::GET => self.get.get(path),
-            Method::PUT => self.put.get(path),
-            Method::POST => self.post.get(path),
-            Method::DELETE => self.delete.get(path),
-            Method::TRACE => self.trace.get(path),
-            Method::OPTIONS => self.options.get(path),
-            Method::CONNECT => self.connect.get(path),
-            Method::PATCH => self.patch.get(path),
-            Method::HEAD => self.head.get(path),
-            _ => None,
-        }
+        Server { router: new_router }
     }
 
     pub fn listen<A: ToSocketAddrs + Display>(self, addr: A) -> ListenResult<()> {
@@ -357,10 +116,18 @@ impl<'a: 'static> Server<'a> {
 }
 type ListenResult<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
-async fn accept_loop(
-    server: Server<'static>,
+async fn accept_loop<PreM, FutP, ResultP, AfterM, FutA, ResultA>(
+    server: Server<PreM, AfterM>,
     addr: impl ToSocketAddrs + Display,
-) -> ListenResult<()> {
+) -> ListenResult<()>
+where
+    PreM: PreMiddleware<FutCallResponse = FutP> + 'static,
+    FutP: Future<Output = ResultP> + std::marker::Send + 'static,
+    ResultP: Into<InternalResult<Request<String>>> + std::marker::Send + 'static,
+    AfterM: AfterMiddleware<FutCallResponse = FutA> + 'static,
+    FutA: Future<Output = ResultA> + std::marker::Send + 'static,
+    ResultA: Into<InternalResult<Response<String>>> + std::marker::Send + 'static,
+{
     let server = Arc::new(server);
     let listener = TcpListener::bind(addr).await.unwrap();
     println!("Start listening on {}", listener.local_addr().unwrap());
@@ -374,10 +141,18 @@ async fn accept_loop(
     Ok(())
 }
 
-fn handle_stream(
-    server: Arc<Server<'static>>,
+fn handle_stream<PreM, FutP, ResultP, AfterM, FutA, ResultA>(
+    server: Arc<Server<PreM, AfterM>>,
     mut stream: TcpStream,
-) -> async_std::task::JoinHandle<()> {
+) -> async_std::task::JoinHandle<()>
+where
+    PreM: PreMiddleware<FutCallResponse = FutP> + 'static,
+    FutP: Future<Output = ResultP> + std::marker::Send + 'static,
+    ResultP: Into<InternalResult<Request<String>>> + std::marker::Send + 'static,
+    AfterM: AfterMiddleware<FutCallResponse = FutA> + 'static,
+    FutA: Future<Output = ResultA> + std::marker::Send + 'static,
+    ResultA: Into<InternalResult<Response<String>>> + std::marker::Send + 'static,
+{
     task::spawn(async move {
         let fut = connection_loop(server, &stream);
         if let Err(e) = fut.await {
@@ -392,10 +167,18 @@ const BAD_REQUEST: &str = "400 Bad Request";
 const NOT_FOUND: &str = "404 Not Found";
 const HTTP_VERSION_NOT_SUPPORTED: &str = "505 HTTP Version Not Supported";
 
-async fn connection_loop(
-    server: Arc<Server<'static>>,
+async fn connection_loop<PreM, FutP, ResultP, AfterM, FutA, ResultA>(
+    server: Arc<Server<PreM, AfterM>>,
     mut stream: impl AsyncRead + AsyncWrite + Unpin,
-) -> ListenResult<()> {
+) -> ListenResult<()>
+where
+    PreM: PreMiddleware<FutCallResponse = FutP> + 'static,
+    FutP: Future<Output = ResultP> + std::marker::Send + 'static,
+    ResultP: Into<InternalResult<Request<String>>> + std::marker::Send + 'static,
+    AfterM: AfterMiddleware<FutCallResponse = FutA> + 'static,
+    FutA: Future<Output = ResultA> + std::marker::Send + 'static,
+    ResultA: Into<InternalResult<Response<String>>> + std::marker::Send + 'static,
+{
     let buf_reader = BufReader::new(&mut stream);
     let mut lines = buf_reader.lines();
     let first_line = lines.next().await;
@@ -435,7 +218,7 @@ async fn connection_loop(
         _ => Err(HTTP_VERSION_NOT_SUPPORTED)?,
     };
 
-    let handler = server.find_handler(&method, &uri.to_string());
+    let handler = server.find_route(&method, &uri.to_string());
     let handler = match handler {
         Some(handler) => handler,
         None => Err(NOT_FOUND)?,
@@ -553,13 +336,15 @@ mod test_utils {
 }
 
 #[cfg(test)]
-mod test_server {
+mod test_server_routing {
 
     use async_std_test::async_test;
+    use futures::Future;
     use serde::{Deserialize, Serialize};
 
     use crate::{
-        handler::{GenericResponse, Json},
+        handler::{GenericResponse, InternalResult, Json},
+        middleware::{AfterMiddleware, PreMiddleware},
         request::{Method, Request},
         response::Response,
     };
@@ -575,12 +360,23 @@ mod test_server {
         Response::new(serde_json::to_string(&TestStruct { correct: true }).unwrap())
     }
 
-    async fn run_test(server: &Server<'static>, req: Request<String>) -> GenericResponse {
+    async fn run_test<PreM, FutP, ResultP, AfterM, FutA, ResultA>(
+        server: &Server<PreM, AfterM>,
+        req: Request<String>,
+    ) -> GenericResponse
+    where
+        PreM: PreMiddleware<FutCallResponse = FutP> + 'static,
+        FutP: Future<Output = ResultP> + std::marker::Send + 'static,
+        ResultP: Into<InternalResult<Request<String>>> + std::marker::Send + 'static,
+        AfterM: AfterMiddleware<FutCallResponse = FutA> + 'static,
+        FutA: Future<Output = ResultA> + std::marker::Send + 'static,
+        ResultA: Into<InternalResult<Response<String>>> + std::marker::Send + 'static,
+    {
         let method = req.method();
 
         let path = req.uri().path().to_string();
 
-        let handler = server.find_handler(method, path.as_str());
+        let handler = server.find_route(method, path.as_str());
 
         assert!(handler.is_some());
 
@@ -591,7 +387,7 @@ mod test_server {
     async fn test_handler_receiving_req_and_res() -> std::io::Result<()> {
         let mut server = Server::new();
 
-        server.add_handler(
+        server.method(
             Method::GET,
             "/aaaa/bbbb",
             test_handler_with_req_and_res,
@@ -752,8 +548,11 @@ mod test_connection_loop {
     use std::sync::Arc;
 
     use async_std_test::async_test;
+    use futures::Future;
     use serde::{Deserialize, Serialize};
 
+    use crate::handler::InternalResult;
+    use crate::middleware::{AfterMiddleware, PreMiddleware};
     use crate::request::Method;
     use crate::response::Response;
     use crate::server::connection_loop;
@@ -794,7 +593,17 @@ mod test_connection_loop {
         request: Request<String>,
     }
 
-    async fn run_test(server: Arc<Server<'static>>, test_config: TestConfig) {
+    async fn run_test<PreM, FutP, ResultP, AfterM, FutA, ResultA>(
+        server: Arc<Server<PreM, AfterM>>,
+        test_config: TestConfig,
+    ) where
+        PreM: PreMiddleware<FutCallResponse = FutP> + 'static,
+        FutP: Future<Output = ResultP> + std::marker::Send + 'static,
+        ResultP: Into<InternalResult<Request<String>>> + std::marker::Send + 'static,
+        AfterM: AfterMiddleware<FutCallResponse = FutA> + 'static,
+        FutA: Future<Output = ResultA> + std::marker::Send + 'static,
+        ResultA: Into<InternalResult<Response<String>>> + std::marker::Send + 'static,
+    {
         // TODO: Implement ToString for Request
         let request = test_config.request;
         let response = test_config.response;
@@ -887,7 +696,18 @@ mod test_connection_loop {
         Json::default()
     );
 
-    async fn test_for_error(server: Arc<Server<'static>>, request: String, response: String) {
+    async fn test_for_error<PreM, FutP, ResultP, AfterM, FutA, ResultA>(
+        server: Arc<Server<PreM, AfterM>>,
+        request: String,
+        response: String,
+    ) where
+        PreM: PreMiddleware<FutCallResponse = FutP> + 'static,
+        FutP: Future<Output = ResultP> + std::marker::Send + 'static,
+        ResultP: Into<InternalResult<Request<String>>> + std::marker::Send + 'static,
+        AfterM: AfterMiddleware<FutCallResponse = FutA> + 'static,
+        FutA: Future<Output = ResultA> + std::marker::Send + 'static,
+        ResultA: Into<InternalResult<Response<String>>> + std::marker::Send + 'static,
+    {
         // TODO: Implement ToString for Request
         let mut stream = MockTcpStream {
             read_data: request.into_bytes(),

--- a/src/server.rs
+++ b/src/server.rs
@@ -82,6 +82,22 @@ where
     FutA: Future<Output = ResultA> + std::marker::Send + 'static,
     ResultA: Into<InternalResult<Response<String>>> + std::marker::Send + 'static,
 {
+    pub fn router<OtherPreM, OtherAfterM, OtherFutA, OtherFutP, OtherResultP, OtherResultA>(
+        self,
+        router: Router<OtherPreM, OtherAfterM>,
+    ) -> Self
+    where
+        OtherPreM: PreMiddleware<FutCallResponse = OtherFutP> + 'static,
+        OtherAfterM: AfterMiddleware<FutCallResponse = OtherFutA> + 'static,
+        OtherFutP: Future<Output = OtherResultP> + Send,
+        OtherFutA: Future<Output = OtherResultA> + Send,
+        OtherResultP: Into<InternalResult<Request<String>>> + Send,
+        OtherResultA: Into<InternalResult<Response<String>>> + Send,
+    {
+        let new_router = self.router.router(router);
+        Self { router: new_router }
+    }
+
     pub fn pre<NewPreM, NewFut, NewResultP>(
         self,
         middleware: NewPreM,


### PR DESCRIPTION
## About

Create the `Router` struct. The name is self-explanatory. We'll use this for the `Server` implementation and as a way for the user to better structure his APIs. It exposes the `MiddlewareFactory` (#8) functionalities allowing the developer to use `Middlewares` directly in his API structure without manually applying it to `Runners` 


## To-do

- [x] Expose functions to add handlers for each HTTP method.
- [x] Expose functions to deal with `Middleware`.
- [x] Make `Server` use `Router` internally.
- [x] Fix `Server` tests.
- [x] Test Routing.
- [x] Test Middleware usage.