### PR TITLE
Refactor/Runner

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
     - name: Build
-      run: cargo build --verbose
+      run: cargo +nightly build --verbose
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo +nightly test --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yahf"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/hello_world/main.rs
+++ b/examples/hello_world/main.rs
@@ -12,5 +12,5 @@ fn main() {
         &String::with_capacity(0),
     );
 
-    a.listen("127.0.0.1:8000").unwrap();
+    a.listen("localhost:8000").unwrap();
 }

--- a/examples/router_example/main.rs
+++ b/examples/router_example/main.rs
@@ -9,6 +9,7 @@ use yahf::handler::Json;
 use yahf::handler::Result;
 use yahf::request::Request;
 
+use yahf::response::Response;
 use yahf::router::Router;
 use yahf::server::Server;
 
@@ -36,6 +37,23 @@ async fn log_middleware(req: Result<Request<String>>) -> Result<Request<String>>
     }
 }
 
+async fn log_error(res: Result<Response<String>>) -> Result<Response<String>> {
+    match res.into_inner() {
+        Err(err) => {
+            println!(
+                "{} - {}",
+                time::SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .expect("Negative time")
+                    .as_millis(),
+                err.code(),
+            );
+            Err(err).into()
+        }
+        ok => ok.into(),
+    }
+}
+
 async fn first_computation(req: ComputationBody) -> ComputationBody {
     ComputationBody {
         value: req.value + 1,
@@ -52,7 +70,7 @@ fn main() {
     let mut router = Router::new().pre(log_middleware);
     router.get("/first", first_computation, &Json::new(), &Json::new());
 
-    let mut server = Server::new();
+    let mut server = Server::new().after(log_error);
     server.get("/second", second_computation, &Json::new(), &Json::new());
 
     let server = server.router(router);

--- a/examples/router_example/main.rs
+++ b/examples/router_example/main.rs
@@ -75,5 +75,5 @@ fn main() {
 
     let server = server.router(router);
 
-    server.listen("localhost:3000").unwrap();
+    server.listen("localhost:8000").unwrap();
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,6 +10,14 @@ impl Error {
     pub fn new(body: String, code: u16) -> Self {
         Self { body, code }
     }
+
+    pub fn body(&self) -> &String {
+        &self.body
+    }
+
+    pub fn code(&self) -> &u16 {
+        &self.code
+    }
 }
 
 impl From<Error> for Response<String> {

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -110,7 +110,6 @@ where
     }
 }
 
-//self.0.and_then(|resp| BasicRunnerOutput::try_into(resp))
 impl<BodyType, Extractor, RInput> RunnerInput<Extractor> for Result<RInput>
 where
     Extractor: BodyDeserializer<Item = BodyType>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(incomplete_features)]
+#![feature(return_position_impl_trait_in_trait)]
 pub mod error;
 pub mod handle_selector;
 pub mod handler;

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -155,10 +155,7 @@ where
             let runner = _runner.clone();
             async move {
                 let req_updated: InternalResult<Request<String>> = pre.call(Ok(req)).await.into();
-                let runner_resp = match req_updated {
-                    Ok(req) => runner.call_runner(req).await,
-                    Err(err) => Err(err),
-                };
+                let runner_resp = runner.call_runner(req_updated).await;
                 let runner_resp_updated: InternalResult<Response<String>> =
                     after.call(runner_resp).await.into();
                 runner_resp_updated
@@ -258,7 +255,7 @@ mod test {
         );
 
         let resp = updated_handler
-            .call_runner(Request::new("From pure request".to_owned()))
+            .call_runner(Request::new("From pure request".to_owned()).into())
             .await;
 
         assert!(resp.unwrap().body() == "From pure request\nFrom middleware\nFrom the handler\nFrom the after middleware");
@@ -280,7 +277,7 @@ mod test {
         );
 
         let resp = updated_handler
-            .call_runner(Request::new("From pure request".to_owned()))
+            .call_runner(Request::new("From pure request".to_owned()).into())
             .await;
 
         assert!(resp.unwrap().body() == "From middleware short-circuiting");
@@ -303,7 +300,7 @@ mod test {
         );
 
         let resp = updated_handler
-            .call_runner(Request::new("From pure request".to_owned()))
+            .call_runner(Request::new("From pure request".to_owned()).into())
             .await;
 
         assert!(resp.unwrap().body() == "From pure request\nFrom middleware\nFrom the handler\nFrom middleware short-circuiting");
@@ -326,7 +323,7 @@ mod test {
         );
 
         let resp = updated_handler
-            .call_runner(Request::new("From pure request".to_owned()))
+            .call_runner(Request::new("From pure request".to_owned()).into())
             .await;
 
         assert!(resp.unwrap().body() == "Error handled");
@@ -350,7 +347,7 @@ mod test {
         );
 
         let resp = updated_handler
-            .call_runner(Request::new("From pure request".to_owned()))
+            .call_runner(Request::new("From pure request".to_owned()).into())
             .await;
 
         assert!(resp.unwrap().body() == "Error handled on after error");
@@ -370,7 +367,7 @@ mod test {
             arc_middleware.build(runner_with_error, &(), &String::with_capacity(0));
 
         let resp = updated_handler
-            .call_runner(Request::new("From pure request".to_owned()))
+            .call_runner(Request::new("From pure request".to_owned()).into())
             .await;
 
         assert!(resp.unwrap().body() == "Error handled on after error");

--- a/src/response.rs
+++ b/src/response.rs
@@ -28,6 +28,7 @@ impl ResponseBuilder {
     }
 }
 
+#[derive(Debug)]
 pub struct Response<T> {
     response: HttpResponse<T>,
 }

--- a/src/router.rs
+++ b/src/router.rs
@@ -99,15 +99,28 @@ where
         OtherResultP: Into<InternalResult<Request<String>>> + Send,
         OtherResultA: Into<InternalResult<Response<String>>> + Send,
     {
-        self.get.extend(router.get);
-        self.put.extend(router.put);
-        self.delete.extend(router.delete);
-        self.post.extend(router.post);
-        self.trace.extend(router.trace);
-        self.options.extend(router.options);
-        self.connect.extend(router.connect);
-        self.patch.extend(router.patch);
-        self.head.extend(router.head);
+        let [get, put, delete, post, trace, options, connect, patch, head] = [
+            router.get,
+            router.put,
+            router.delete,
+            router.post,
+            router.trace,
+            router.options,
+            router.connect,
+            router.patch,
+            router.head,
+        ]
+        .map(|handler| handler.apply(self.middleware_factory.clone()));
+
+        self.get.extend(get);
+        self.put.extend(put);
+        self.delete.extend(delete);
+        self.post.extend(post);
+        self.trace.extend(trace);
+        self.options.extend(options);
+        self.connect.extend(connect);
+        self.patch.extend(patch);
+        self.head.extend(head);
 
         self
     }
@@ -340,7 +353,7 @@ mod test {
             runner: RefHandler<'_>,
             request: InternalResult<Request<String>>,
         ) -> InternalResult<Response<String>> {
-            runner(request).await
+            runner.call(request).await
         }
     }
 

--- a/src/router.rs
+++ b/src/router.rs
@@ -398,7 +398,7 @@ mod test {
                 let response = super::utils::run_runner(handler.unwrap(), request.into()).await;
 
                 super::utils::test_runner_response(
-                    response.unwrap().body().to_owned(),
+                    response.map_or_else(|err| err.into(), |res| res).body().to_owned(),
                     $expected_body.to_owned(),
                 );
 

--- a/src/router.rs
+++ b/src/router.rs
@@ -320,7 +320,7 @@ mod test {
 
     mod utils {
         use crate::{
-            handler::RefHandler,
+            handler::{InternalResult, RefHandler},
             request::{Method, Request},
             response::Response,
         };
@@ -338,8 +338,8 @@ mod test {
 
         pub async fn run_runner(
             runner: RefHandler<'_>,
-            request: Request<String>,
-        ) -> Response<String> {
+            request: InternalResult<Request<String>>,
+        ) -> InternalResult<Response<String>> {
             runner(request).await
         }
     }
@@ -382,10 +382,10 @@ mod test {
 
                 assert!(handler.is_some());
 
-                let response = super::utils::run_runner(handler.unwrap(), request).await;
+                let response = super::utils::run_runner(handler.unwrap(), request.into()).await;
 
                 super::utils::test_runner_response(
-                    response.body().to_owned(),
+                    response.unwrap().body().to_owned(),
                     $expected_body.to_owned(),
                 );
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -291,7 +291,9 @@ where
 
     let request = request_builder.body(body_string);
 
-    let response = handler(request).await;
+    let response = handler(request.into())
+        .await
+        .map_or_else(|err| err.into(), |resp| resp);
 
     let response_string = format!(
         "HTTP/1.1 {} {}\r\n{}\r\n{}",
@@ -406,7 +408,7 @@ mod test_server_routing {
 
         assert!(handler.is_some());
 
-        handler.unwrap()(req).await
+        handler.unwrap()(req.into()).await.unwrap()
     }
 
     #[async_test]
@@ -581,8 +583,8 @@ mod test_connection_loop {
     use crate::middleware::{AfterMiddleware, PreMiddleware};
     use crate::request::Method;
     use crate::response::Response;
+    use crate::server::connection_loop;
     use crate::server::test_utils::MockTcpStream;
-    use crate::server::{connection_loop, handle_stream};
     use crate::{handler::Json, request::Request, server::Server};
 
     #[derive(Debug, Deserialize, Serialize, PartialEq)]

--- a/src/server.rs
+++ b/src/server.rs
@@ -146,7 +146,6 @@ where
 
     while let Some(stream) = incoming.next().await {
         let stream = stream?;
-        println!("Accepting from: {}", stream.peer_addr()?);
         handle_stream(server.clone(), stream);
     }
     Ok(())

--- a/src/server.rs
+++ b/src/server.rs
@@ -291,7 +291,8 @@ where
 
     let request = request_builder.body(body_string);
 
-    let response = handler(request.into())
+    let response = handler
+        .call(request.into())
         .await
         .map_or_else(|err| err.into(), |resp| resp);
 
@@ -408,7 +409,7 @@ mod test_server_routing {
 
         assert!(handler.is_some());
 
-        handler.unwrap()(req.into()).await.unwrap()
+        handler.unwrap().call(req.into()).await.unwrap()
     }
 
     #[async_test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -168,8 +168,7 @@ where
         let response = match fut.await {
             Ok(resp) => resp,
             Err(err) => {
-                println!("{}", err);
-                format!("HTTP/1.1 {}", err)
+                format!("HTTP/1.1 {}\r\n\r\n", err)
             }
         };
 


### PR DESCRIPTION
## About

Change `Runner` to accept as an argument for `call_runner` the `InternalResult<Request<String>>` to improve code consistency and allow the application of `Middleware` in a `Router` extension.

Here we already have the implementation of the extension.

## Caution

There are replicated code changes from #9 because this branch was based on that PR.

This PR requires [features](https://github.com/orgs/rust-lang/projects/28/views/2?pane=issue&itemId=29158881) currently on Rust Nightly, but these are expected to be in the next stable version of Rust.